### PR TITLE
feat: implement meeting history with IndexedDB

### DIFF
--- a/index.html
+++ b/index.html
@@ -1788,7 +1788,16 @@
     <div class="panel active" id="transcriptPanel">
       <div class="panel-header">
         <span class="panel-title">📝 <span data-i18n="app.panel.transcript">文字起こし</span></span>
-        <button class="btn btn-ghost" id="clearTranscriptBtn" style="font-size: 0.75rem;" data-i18n="common.clear">クリア</button>
+        <div class="panel-actions" style="display:flex; gap:0.5rem;">
+          <button class="btn btn-ghost" id="openHistoryBtn" style="font-size:0.75rem;">🗂️ <span data-i18n="history.open">履歴</span></button>
+          <button class="btn btn-ghost" id="clearTranscriptBtn" style="font-size: 0.75rem;" data-i18n="common.clear">クリア</button>
+        </div>
+      </div>
+      <div class="meeting-title-row" style="display:flex; gap:0.5rem; align-items:center; margin:0.5rem 0;">
+        <label for="meetingTitleInput" class="meeting-title-label" style="font-size:0.9rem; color:var(--text-secondary);">
+          <span data-i18n="history.titleLabel">会議タイトル</span>
+        </label>
+        <input type="text" id="meetingTitleInput" class="input" style="flex:1;" data-i18n-placeholder="history.titlePlaceholder" placeholder="例: 営業定例 (2026/01/06)">
       </div>
       <div class="panel-body" id="transcriptBody">
         <div class="transcript-text" id="transcriptText"><span class="transcript-placeholder" id="transcriptPlaceholder" data-i18n="app.transcript.placeholder">録音を開始すると、ここに文字起こしが表示されます...</span></div>
@@ -2050,6 +2059,24 @@
     </div>
   </div>
 
+  <!-- 履歴モーダル -->
+  <div class="modal-overlay" id="historyModal">
+    <div class="modal" style="max-width:700px;">
+      <div class="modal-header">
+        <h2>🗂️ <span data-i18n="history.modalTitle">会議履歴</span></h2>
+        <button class="modal-close" id="closeHistoryModalBtn">×</button>
+      </div>
+      <div class="modal-body">
+        <p style="margin-bottom:0.75rem; font-size:0.9rem; color:var(--text-secondary);" data-i18n="history.modalDescription">最大5件まで自動保存され、古い履歴から削除されます。</p>
+        <div id="historyList" class="history-list" data-i18n-empty="history.empty" style="display:flex; flex-direction:column; gap:0.75rem;"></div>
+      </div>
+      <div class="modal-footer" style="justify-content:space-between;">
+        <button class="btn btn-ghost" id="clearHistoryBtn">🧹 <span data-i18n="history.clearAll">履歴を全て削除</span></button>
+        <button class="btn btn-secondary" id="closeHistoryModalFooterBtn" data-i18n="common.close">閉じる</button>
+      </div>
+    </div>
+  </div>
+
   <!-- トースト通知コンテナ -->
   <div class="toast-container" id="toastContainer"></div>
 
@@ -2082,6 +2109,7 @@
   <script src="js/i18n.js"></script>
   <script src="js/theme.js"></script>
   <script src="js/secure-storage.js" defer></script>
+  <script src="js/history-store.js" defer></script>
   <!-- STT Provider抽象化レイヤー -->
   <script src="js/audio/pcm_stream.js" defer></script>
   <script src="js/stt/index.js" defer></script>

--- a/js/history-store.js
+++ b/js/history-store.js
@@ -1,0 +1,151 @@
+// =====================================
+// 会議履歴 IndexedDB ストア
+// =====================================
+(function(global) {
+  const DB_NAME = 'aiMeetingHistory';
+  const DB_VERSION = 1;
+  const STORE_NAME = 'records';
+  const MAX_RECORDS = 5;
+
+  if (!global.indexedDB) {
+    console.warn('[HistoryStore] IndexedDB is not supported in this environment.');
+    return;
+  }
+
+  function openDB() {
+    return new Promise((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, DB_VERSION);
+      request.onerror = () => reject(request.error);
+      request.onupgradeneeded = event => {
+        const db = event.target.result;
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          const store = db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+          store.createIndex('createdAt', 'createdAt', { unique: false });
+        }
+      };
+      request.onsuccess = () => resolve(request.result);
+    });
+  }
+
+  async function saveRecord(record) {
+    if (!record || !record.id) {
+      throw new Error('Invalid history record payload');
+    }
+    const db = await openDB();
+    const now = new Date().toISOString();
+    const payload = {
+      createdAt: record.createdAt || now,
+      ...record,
+      updatedAt: now
+    };
+
+    await new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      const store = tx.objectStore(STORE_NAME);
+      const req = store.put(payload);
+      req.onsuccess = resolve;
+      req.onerror = () => reject(req.error);
+      tx.onerror = () => reject(tx.error);
+    });
+
+    await enforceLimit(db);
+  }
+
+  async function enforceLimit(db) {
+    await new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      const store = tx.objectStore(STORE_NAME);
+      const countRequest = store.count();
+      countRequest.onsuccess = () => {
+        const total = countRequest.result || 0;
+        const excess = total - MAX_RECORDS;
+        if (excess <= 0) {
+          resolve();
+          return;
+        }
+        const index = store.index('createdAt');
+        const cursorRequest = index.openCursor(null, 'next'); // oldest first
+        let toDelete = excess;
+        cursorRequest.onsuccess = event => {
+          const cursor = event.target.result;
+          if (!cursor || toDelete <= 0) return;
+          const deleteRequest = cursor.delete();
+          deleteRequest.onsuccess = () => {
+            toDelete--;
+            cursor.continue();
+          };
+          deleteRequest.onerror = () => reject(deleteRequest.error);
+        };
+        cursorRequest.onerror = () => reject(cursorRequest.error);
+      };
+      countRequest.onerror = () => reject(countRequest.error);
+      tx.oncomplete = resolve;
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  function listRecords() {
+    return openDB().then(db => {
+      return new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readonly');
+        const store = tx.objectStore(STORE_NAME);
+        const index = store.index('createdAt');
+        const results = [];
+        const cursor = index.openCursor(null, 'prev'); // newest first
+        cursor.onsuccess = event => {
+          const cur = event.target.result;
+          if (cur) {
+            results.push(cur.value);
+            cur.continue();
+          } else {
+            resolve(results);
+          }
+        };
+        cursor.onerror = () => reject(cursor.error);
+      });
+    });
+  }
+
+  function getRecord(id) {
+    if (!id) return Promise.resolve(null);
+    return openDB().then(db => {
+      return new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readonly');
+        const req = tx.objectStore(STORE_NAME).get(id);
+        req.onsuccess = () => resolve(req.result || null);
+        req.onerror = () => reject(req.error);
+      });
+    });
+  }
+
+  function deleteRecord(id) {
+    if (!id) return Promise.resolve();
+    return openDB().then(db => {
+      return new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readwrite');
+        const req = tx.objectStore(STORE_NAME).delete(id);
+        req.onsuccess = () => resolve();
+        req.onerror = () => reject(req.error);
+      });
+    });
+  }
+
+  function clearRecords() {
+    return openDB().then(db => {
+      return new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readwrite');
+        const req = tx.objectStore(STORE_NAME).clear();
+        req.onsuccess = () => resolve();
+        req.onerror = () => reject(req.error);
+      });
+    });
+  }
+
+  global.HistoryStore = {
+    save: saveRecord,
+    list: listRecords,
+    get: getRecord,
+    delete: deleteRecord,
+    clear: clearRecords
+  };
+})(window);

--- a/locales/en.json
+++ b/locales/en.json
@@ -256,6 +256,16 @@
       "copyFallback": "Popup blocked. Please copy from the preview",
       "selectItems": "Please select items to export"
     },
+    "history": {
+      "saved": "Saved to history",
+      "failed": "History operation failed: {message}",
+      "deleted": "History entry deleted",
+      "cleared": "All history deleted",
+      "success": "Downloaded from history",
+      "shared": "Share sheet opened. Select 'Save to Files' to save",
+      "openedInNewTab": "Opened in new tab. Long-press or use share button to save",
+      "copyFallback": "Popup blocked. Please copy from the preview"
+    },
     "llm": {
       "notConfigured": "LLM API key not set. Please register an API key in settings."
     },
@@ -339,6 +349,23 @@
       "costOutputTokens": "Output Tokens",
       "costDisclaimer": "These amounts are estimates. Actual charges may differ."
     }
+  },
+  "history": {
+    "open": "History",
+    "titleLabel": "Meeting title",
+    "titlePlaceholder": "e.g., Sales Weekly (2026-01-06)",
+    "modalTitle": "Meeting History",
+    "modalDescription": "Up to 5 recent meetings are stored locally. Older entries are removed automatically.",
+    "empty": "No saved meetings yet. Stop a recording to auto-save.",
+    "clearAll": "Delete all history",
+    "clearConfirm": "Delete all saved meetings? This action cannot be undone.",
+    "download": "Download",
+    "delete": "Delete",
+    "defaultTitle": "Meeting on {date}",
+    "recordSavedAt": "Saved",
+    "recordDuration": "Duration",
+    "notSupported": "History is not available in this browser.",
+    "missingRecord": "Record not found"
   },
   "modal": {
     "welcome": {

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -255,6 +255,16 @@
       "copyFallback": "ポップアップがブロックされました。プレビューからコピーしてください",
       "selectItems": "エクスポートする項目を選択してください"
     },
+    "history": {
+      "saved": "履歴に保存しました",
+      "failed": "履歴処理に失敗しました: {message}",
+      "deleted": "履歴を削除しました",
+      "cleared": "履歴をすべて削除しました",
+      "success": "履歴からダウンロードしました",
+      "shared": "共有シートを開きました。「ファイルに保存」を選択してください",
+      "openedInNewTab": "新しいタブで開きました。長押しまたは共有ボタンから保存できます",
+      "copyFallback": "ポップアップがブロックされました。プレビューからコピーしてください"
+    },
     "llm": {
       "notConfigured": "LLM APIキーが未設定です。設定画面でAPIキーを登録してください。"
     },
@@ -338,6 +348,23 @@
       "costOutputTokens": "出力トークン",
       "costDisclaimer": "この金額は概算です。実際の請求額とは異なる場合があります。"
     }
+  },
+  "history": {
+    "open": "履歴",
+    "titleLabel": "会議タイトル",
+    "titlePlaceholder": "例: 営業定例 (2026/01/06)",
+    "modalTitle": "会議履歴",
+    "modalDescription": "直近5件の会議が自動保存され、古い履歴から削除されます。",
+    "empty": "まだ保存された会議はありません。録音停止後に自動保存されます。",
+    "clearAll": "履歴を全て削除",
+    "clearConfirm": "保存済みの会議をすべて削除しますか？ この操作は元に戻せません。",
+    "download": "ダウンロード",
+    "delete": "削除",
+    "defaultTitle": "{date}の会議",
+    "recordSavedAt": "保存",
+    "recordDuration": "所要時間",
+    "notSupported": "このブラウザでは履歴機能を利用できません。",
+    "missingRecord": "履歴が見つかりません"
   },
   "modal": {
     "welcome": {


### PR DESCRIPTION
## Summary
- add IndexedDB-backed HistoryStore that keeps the latest five meetings and exposes save/list/get/delete helpers (browser-guarded)
- extend transcript panel with meeting title input, history button, and modal UI to browse/download/delete stored entries
- hook stopRecording → snapshot save, reuse download logic for history exports, and localize every new label/toast (en/ja)

Resolves #13.