### PR TITLE
feat(ui): add LLM quick settings modal and popup settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,6 +149,61 @@
       background: var(--border);
     }
 
+    .quick-settings-btn {
+      display: flex;
+      align-items: center;
+      padding: 0.375rem;
+      border-radius: 0.375rem;
+      opacity: 0.7;
+      transition: opacity 0.2s, background 0.2s;
+      font-size: 1.1rem;
+      background: none;
+      border: none;
+      cursor: pointer;
+    }
+
+    .quick-settings-btn:hover {
+      opacity: 1;
+      background: var(--border);
+    }
+
+    /* LLM設定モーダル */
+    .llm-provider-tabs {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+
+    .llm-provider-tab {
+      padding: 0.5rem 1rem;
+      border: 1px solid var(--border);
+      border-radius: 0.5rem;
+      background: var(--card-bg);
+      cursor: pointer;
+      font-size: 0.875rem;
+      transition: all 0.2s;
+    }
+
+    .llm-provider-tab:hover {
+      border-color: var(--primary);
+      background: var(--accent-blue);
+    }
+
+    .llm-provider-tab.active {
+      border-color: var(--primary);
+      background: var(--primary);
+      color: white;
+    }
+
+    .llm-key-hint {
+      font-size: 0.75rem;
+      margin-top: 0.25rem;
+    }
+
+    .llm-key-hint a {
+      color: var(--primary);
+    }
+
     /* Row 2: 操作ツールバー */
     .header-row-2 {
       display: flex;
@@ -1734,7 +1789,8 @@
           <option value="ja">🇯🇵 Japanese</option>
           <option value="en">🇺🇸 English</option>
         </select>
-        <a href="config.html" class="settings-link" data-i18n-title="common.settings">⚙️</a>
+        <button type="button" class="quick-settings-btn" id="openLLMSettingsBtn" data-i18n-title="llmModal.title" title="LLM設定">⚡</button>
+        <button type="button" class="settings-link" id="openFullSettingsBtn" data-i18n-title="header.fullSettings" title="全設定">⚙️</button>
       </div>
     </div>
 
@@ -2093,7 +2149,7 @@
     </div>
   </div>
 
-  <!-- 履歴モーダル -->
+<!-- 履歴モーダル -->
   <div class="modal-overlay" id="historyModal">
     <div class="modal" style="max-width:700px;">
       <div class="modal-header">
@@ -2107,6 +2163,45 @@
       <div class="modal-footer" style="justify-content:space-between;">
         <button class="btn btn-ghost" id="clearHistoryBtn">🧹 <span data-i18n="history.clearAll">履歴を全て削除</span></button>
         <button class="btn btn-secondary" id="closeHistoryModalFooterBtn" data-i18n="common.close">閉じる</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- LLM設定モーダル -->
+  <div class="modal-overlay" id="llmSettingsModal">
+    <div class="modal" style="max-width: 450px;">
+      <div class="modal-header">
+        <h2>⚡ <span data-i18n="llmModal.title">LLM設定</span></h2>
+        <button class="modal-close" id="closeLLMModalBtn">×</button>
+      </div>
+      <div class="modal-body">
+        <div class="setting-group">
+          <label class="setting-label" data-i18n="llmModal.selectProvider">プロバイダーを選択</label>
+          <div class="llm-provider-tabs">
+            <button type="button" class="llm-provider-tab active" data-provider="gemini">Gemini</button>
+            <button type="button" class="llm-provider-tab" data-provider="claude">Claude</button>
+            <button type="button" class="llm-provider-tab" data-provider="openai_llm">OpenAI</button>
+            <button type="button" class="llm-provider-tab" data-provider="groq">Groq</button>
+          </div>
+        </div>
+        <div class="setting-group">
+          <label class="setting-label" data-i18n="llmModal.apiKey">APIキー</label>
+          <input type="password" class="setting-input" id="llmModalApiKey" placeholder="APIキーを入力">
+          <div class="setting-hint llm-key-hint" id="llmKeyHint"></div>
+        </div>
+        <div class="setting-group">
+          <label class="setting-label" data-i18n="llmModal.model">モデル</label>
+          <select class="setting-input model-select" id="llmModalModel"></select>
+        </div>
+        <div class="setting-group" style="margin-top: 1rem; padding: 0.75rem; background: var(--accent-blue); border-radius: 0.5rem; border: 1px solid var(--accent-border-blue);">
+          <div style="font-size: 0.8rem; color: var(--text-secondary);" data-i18n="llmModal.hint">
+            💡 録音中でもLLM設定を変更できます。次回のAI呼び出しから新しい設定が適用されます。
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-secondary" id="closeLLMModalFooterBtn" data-i18n="common.cancel">キャンセル</button>
+        <button class="btn btn-primary" id="saveLLMModalBtn">💾 <span data-i18n="common.save">保存</span></button>
       </div>
     </div>
   </div>

--- a/locales/en.json
+++ b/locales/en.json
@@ -380,6 +380,18 @@
       "startButton": "Start Configuration"
     }
   },
+  "llmModal": {
+    "title": "LLM Settings",
+    "selectProvider": "Select Provider",
+    "apiKey": "API Key",
+    "model": "Model",
+    "hint": "💡 You can change LLM settings while recording. The new settings will apply from the next AI call.",
+    "saved": "LLM settings saved"
+  },
+  "header": {
+    "llmSettings": "LLM Settings",
+    "fullSettings": "All Settings"
+  },
   "footer": {
     "terms": "Terms of Service",
     "privacy": "Privacy Policy",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -379,6 +379,18 @@
       "startButton": "設定を開始する"
     }
   },
+  "llmModal": {
+    "title": "LLM設定",
+    "selectProvider": "プロバイダーを選択",
+    "apiKey": "APIキー",
+    "model": "モデル",
+    "hint": "💡 録音中でもLLM設定を変更できます。次回のAI呼び出しから新しい設定が適用されます。",
+    "saved": "LLM設定を保存しました"
+  },
+  "header": {
+    "llmSettings": "LLM設定",
+    "fullSettings": "全設定"
+  },
   "footer": {
     "terms": "利用規約",
     "privacy": "プライバシーポリシー",


### PR DESCRIPTION
## Summary

Issue #12 の対応: 設定画面遷移時の文字起こしデータ消失を防止

- ⚡ **LLMクイック設定モーダル**: 録音中でもLLM設定を変更可能（ページ遷移なし）
- ⚙️ **全設定ポップアップ**: config.htmlを別窓で開く（メイン画面の録音継続）

## Changes

| ファイル | 変更内容 |
|----------|----------|
| `index.html` | LLMモーダルHTML + CSS + ヘッダーUI変更 |
| `js/app.js` | モーダル処理 + ポップアップ起動 |
| `locales/ja.json` | i18nキー追加 |
| `locales/en.json` | i18nキー追加 |

## Features

- LLMプロバイダータブ切り替え（Gemini/Claude/OpenAI/Groq）
- APIキー・モデル選択の即時保存（localStorage）
- 設定変更は次回LLM呼び出しから即座に反映
- 録音・文字起こしは中断されない

## Test plan

- [ ] 録音中に⚡LLM設定 → モーダル表示 → 録音継続確認
- [ ] モーダルでLLMキー変更 → 要約ボタン → 新キーで動作確認
- [ ] 録音中に⚙️全設定 → ポップアップ表示 → 録音継続確認
- [ ] ポップアップで設定保存 → メイン窓でLLM呼び出し → 新設定反映確認

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)