### PR TITLE
feat(recording): add pause/resume functionality (#27)

### DIFF
--- a/index.html
+++ b/index.html
@@ -445,6 +445,12 @@
       animation: pulse 1.5s infinite;
     }
 
+    .status-paused {
+      background: #fef3c7;
+      color: #92400e;
+      border-color: #fcd34d;
+    }
+
     @keyframes pulse {
       0%, 100% { opacity: 1; }
       50% { opacity: 0.6; }
@@ -1987,6 +1993,9 @@
         <button type="button" class="btn btn-primary record-btn" id="recordBtn">
           <span data-i18n="app.recording.start">🎤 録音開始</span>
         </button>
+        <button type="button" class="btn btn-secondary record-btn" id="pauseBtn" style="display: none;">
+          <span data-i18n="app.recording.pause">Pause</span>
+        </button>
         <span class="status-badge status-ready" id="statusBadge">
           <span data-i18n="app.recording.statusReady">待機中</span>
         </span>
@@ -2447,7 +2456,7 @@
   <div class="meeting-mode-overlay" id="meetingModeOverlay">
     <div class="meeting-mode-status">
       <div class="meeting-mode-icon">🔴</div>
-      <div class="meeting-mode-text" data-i18n="app.meeting.recording">録音中</div>
+      <div class="meeting-mode-text" id="meetingModeStatusText" data-i18n="app.meeting.recording">録音中</div>
       <div class="meeting-mode-time" id="meetingModeTime">00:00:00</div>
       <div class="meeting-mode-hint" data-i18n="app.meeting.focusHint">会議に集中してください</div>
     </div>

--- a/locales/en.json
+++ b/locales/en.json
@@ -28,8 +28,11 @@
     "recording": {
       "start": "Start Recording",
       "stop": "Stop Recording",
+      "pause": "Pause",
+      "resume": "Resume",
       "statusReady": "Ready",
       "statusRecording": "Recording",
+      "statusPaused": "Paused",
       "statusConnecting": "Connecting",
       "statusReconnecting": "Reconnecting",
       "statusDisconnected": "Disconnected",
@@ -91,6 +94,7 @@
     "meeting": {
       "modeButton": "Meeting Mode",
       "recording": "Recording",
+      "paused": "Paused",
       "focusHint": "Focus on your meeting",
       "returnButton": "Return to normal view"
     },
@@ -245,6 +249,8 @@
   "toast": {
     "recording": {
       "started": "Recording started ({provider})",
+      "paused": "Recording paused",
+      "resumed": "Recording resumed",
       "stopped": "Recording stopped",
       "interrupted": "Recording interrupted. Content saved. Press record button to continue"
     },

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -28,8 +28,11 @@
     "recording": {
       "start": "録音開始",
       "stop": "録音停止",
+      "pause": "一時停止",
+      "resume": "再開",
       "statusReady": "待機中",
       "statusRecording": "録音中",
+      "statusPaused": "一時停止中",
       "statusConnecting": "接続中",
       "statusReconnecting": "再接続中",
       "statusDisconnected": "切断",
@@ -91,6 +94,7 @@
     "meeting": {
       "modeButton": "会議中モード",
       "recording": "録音中",
+      "paused": "一時停止中",
       "focusHint": "会議に集中してください",
       "returnButton": "通常画面に戻る"
     },
@@ -244,6 +248,8 @@
   "toast": {
     "recording": {
       "started": "録音を開始しました（{provider}）",
+      "paused": "録音を一時停止しました",
+      "resumed": "録音を再開しました",
       "stopped": "録音を停止しました",
       "interrupted": "録音が中断されました。ここまでの内容は保存されています。録音ボタンで再開できます"
     },


### PR DESCRIPTION
## Summary
- 録音中に一時停止・再開機能を追加
- STTへの音声送信を一時停止し、再開ボタンで続きから文字起こしを継続
- 一時停止中の累計時間を記録し、経過時間表示に反映

## Changes
- **index.html**: 一時停止ボタン (`#pauseBtn`) を追加
- **js/app.js**: 
  - `pauseRecording()` / `resumeRecording()` 関数を実装
  - 状態管理変数 (`isPaused`, `pausedTotalMs`, `pauseStartedAt`) を追加
  - UI更新ロジックを拡張
- **locales/ja.json** & **locales/en.json**: i18nキーを追加

## Test plan
- [x] 一時停止ボタンが録音中のみ表示される
- [x] 一時停止時にボタンが「再開」に変化
- [x] ステータスバッジが「一時停止中」に変化
- [x] i18nキーが日本語・英語で正しく定義されている

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)