### PR TITLE
chore: fix escapeHtml duplication and add missing i18n key (#28)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -4525,15 +4525,6 @@ function calculateTotalContextChars() {
   return total;
 }
 
-/**
- * HTMLエスケープ
- */
-function escapeHtml(text) {
-  const div = document.createElement('div');
-  div.textContent = text;
-  return div.innerHTML;
-}
-
 // =====================================
 // LLMインジケーター
 // =====================================

--- a/locales/en.json
+++ b/locales/en.json
@@ -205,6 +205,7 @@
       "clearOnClose": "Auto-delete API keys when browser closes (for shared PCs)",
       "costAlertTitle": "Cost Alert",
       "costLimit": "Session cost limit (JPY)",
+      "costLimitPlaceholder": "e.g. 100",
       "costAlertEnabled": "Show warning at 80% of limit",
       "enhancedContextTitle": "Enhanced Context",
       "enhancedContextEnabled": "Enable file attachments for meeting context",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -204,6 +204,7 @@
       "clearOnClose": "ブラウザを閉じたらAPIキーを自動削除（共有PC向け）",
       "costAlertTitle": "コストアラート",
       "costLimit": "1セッションの上限金額（円）",
+      "costLimitPlaceholder": "例: 100",
       "costAlertEnabled": "上限の80%で警告を表示",
       "enhancedContextTitle": "強化コンテキスト",
       "enhancedContextEnabled": "ファイル添付による会議資料の提供を有効化",


### PR DESCRIPTION
## Summary
PR #26 マージ後のフォローアップとして、2つの軽微な問題を修正しました。

### 1. escapeHtml の重複定義を整理
- `js/app.js` 内で `escapeHtml()` が2箇所で定義されていた問題を修正
- 1389行目の定義を残し、4528-4535行目の重複定義を削除
- 機能に変更なし、保守性向上

### 2. i18n キー欠落を修正
- `config.options.costLimitPlaceholder` が `config.html` で参照されているが、locale ファイルに未定義だった
- `locales/ja.json`: `"costLimitPlaceholder": "例: 100"` を追加
- `locales/en.json`: `"costLimitPlaceholder": "e.g. 100"` を追加

## Test plan
- [x] escapeHtml が1箇所のみに存在することを確認
- [x] escapeHtml 関数が正常に動作（XSS防止テスト）
- [x] costLimitPlaceholder が設定画面で正しく表示される
- [x] アプリ全体の動作に回帰がないこと

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)