### PR TITLE
Quality sprint: P1 fixes + session-only keys + fatal error recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Check JS syntax
+        run: |
+          echo "Checking JavaScript syntax..."
+          for f in js/*.js; do
+            echo "  Checking $f"
+            node --check "$f"
+          done
+          echo "All JS files passed syntax check"
+
+      - name: Check JSON validity (locales)
+        run: |
+          echo "Checking JSON validity..."
+          for f in locales/*.json; do
+            echo "  Checking $f"
+            node -e "JSON.parse(require('fs').readFileSync('$f', 'utf8'))"
+          done
+          echo "All JSON files are valid"
+
+      - name: Check required docs exist
+        run: |
+          echo "Checking required documentation..."
+          test -f docs/RELEASE_CHECKLIST.md && echo "  docs/RELEASE_CHECKLIST.md exists"
+          test -f docs/SECURITY.md && echo "  docs/SECURITY.md exists"
+          test -f docs/PRIVACY.md && echo "  docs/PRIVACY.md exists"
+          echo "All required docs present"

--- a/config.html
+++ b/config.html
@@ -725,6 +725,11 @@
       <div class="security-options">
         <div class="security-options-title">🛡️ <span data-i18n="config.options.securityTitle">Security Options</span></div>
         <div class="checkbox-group">
+          <input type="checkbox" id="persistApiKeys">
+          <label for="persistApiKeys" data-i18n="config.storage.persistLabel">Persist API keys across sessions (not recommended)</label>
+        </div>
+        <div class="setting-hint" style="font-size: 0.75rem; color: var(--text-secondary); margin-top: 0.25rem; margin-bottom: 0.5rem;" data-i18n="config.storage.persistWarning">Not recommended on shared devices. Keys remain in this browser.</div>
+        <div class="checkbox-group">
           <input type="checkbox" id="clearOnClose">
           <label for="clearOnClose" data-i18n="config.options.clearOnClose">Auto-delete API keys when browser closes (for shared PCs)</label>
         </div>

--- a/index.html
+++ b/index.html
@@ -1192,6 +1192,17 @@
       border-radius: 4px;
     }
 
+    .transcript-truncated-notice {
+      background: var(--bg-secondary);
+      color: var(--text-secondary);
+      padding: 0.5rem 1rem;
+      font-size: 0.85rem;
+      margin-bottom: 0.5rem;
+      border-radius: 4px;
+      text-align: center;
+      border: 1px dashed var(--border);
+    }
+
     /* 設定インポート/エクスポート */
     .settings-transfer {
       margin-top: 1.5rem;
@@ -2477,6 +2488,50 @@
       <div class="modal-footer">
         <button class="btn btn-secondary" id="closeLLMModalFooterBtn" data-i18n="common.cancel">キャンセル</button>
         <button class="btn btn-primary" id="saveLLMModalBtn">💾 <span data-i18n="common.save">保存</span></button>
+      </div>
+    </div>
+  </div>
+
+  <!-- API Key Storage Migration Modal (Issue #41) -->
+  <div class="modal-overlay" id="storageMigrationModal" style="display: none;">
+    <div class="modal" style="max-width: 450px;">
+      <div class="modal-header">
+        <h2 data-i18n="config.storage.migrationTitle">APIキー保存方式が変わりました</h2>
+      </div>
+      <div class="modal-body">
+        <p style="margin-bottom: 1rem;" data-i18n="config.storage.migrationBody">
+          安全性向上のため、APIキーは通常セッション内のみ保持されます。次回からどうしますか？
+        </p>
+        <div style="display: flex; flex-direction: column; gap: 0.75rem;">
+          <button class="btn btn-primary" id="migrateToSessionBtn">
+            <span data-i18n="config.storage.sessionOnly">セッションのみ（推奨）</span>
+          </button>
+          <button class="btn btn-secondary" id="keepPersistentBtn">
+            <span data-i18n="config.storage.persistKeys">端末に保存する</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Issue #40: Fatal error modal -->
+  <div class="modal-overlay" id="fatalErrorModal" style="display: none;">
+    <div class="modal" style="max-width: 400px;">
+      <div class="modal-header">
+        <h2 data-i18n="app.error.fatalTitle">エラーが発生しました</h2>
+      </div>
+      <div class="modal-body">
+        <p style="margin-bottom: 1rem;" data-i18n="app.error.fatalBody">
+          予期しないエラーが発生しました。録音中の場合は自動停止されました。
+        </p>
+        <div style="display: flex; flex-direction: column; gap: 0.75rem;">
+          <button class="btn btn-primary" id="resetSessionBtn">
+            <span data-i18n="app.error.resetSession">セッションをリセット</span>
+          </button>
+          <button class="btn btn-secondary" id="reloadPageBtn">
+            <span data-i18n="app.error.reloadPage">ページを再読み込み</span>
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/locales/en.json
+++ b/locales/en.json
@@ -105,7 +105,8 @@
       "exclude": "Exclude this segment",
       "restore": "Restore this segment",
       "copySegment": "Copy this segment",
-      "clearConfirm": "Clear all transcription?"
+      "clearConfirm": "Clear all transcription?",
+      "truncatedNotice": "{{count}} earlier segments not shown (available in export)"
     },
     "aiResponse": {
       "placeholder": "AI responses will appear here when you ask a question...",
@@ -116,6 +117,12 @@
       "incompatibleMessage": "Some features are not supported in your browser. Please use the latest version of Chrome, Edge, or Safari.",
       "incompatibleButton": "⚠️ Unsupported Browser",
       "incompatibleTooltip": "The following features are not available: {features}"
+    },
+    "error": {
+      "fatalTitle": "An error occurred",
+      "fatalBody": "An unexpected error occurred. Recording has been stopped automatically if in progress.",
+      "resetSession": "Reset Session",
+      "reloadPage": "Reload Page"
     }
   },
   "config": {
@@ -130,6 +137,15 @@
       "httpsOnly": "Only sent via HTTPS during API calls",
       "isolated": "Inaccessible from other websites",
       "exportable": "Import/export settings supported"
+    },
+    "storage": {
+      "migrationTitle": "API Key Storage Update",
+      "migrationBody": "For improved security, API keys are now session-only by default. How would you like to proceed?",
+      "sessionOnly": "Session only (Recommended)",
+      "persistKeys": "Save to device",
+      "persistLabel": "Persist API keys across sessions (not recommended)",
+      "persistWarning": "Not recommended on shared devices. Keys remain in this browser.",
+      "sessionNotice": "This key will be lost when you close the tab"
     },
     "stt": {
       "title": "Transcription (STT) - Provider Selection",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -105,7 +105,8 @@
       "exclude": "この文節を除外",
       "restore": "この文節を復元",
       "copySegment": "この文節をコピー",
-      "clearConfirm": "文字起こしをクリアしますか？"
+      "clearConfirm": "文字起こしをクリアしますか？",
+      "truncatedNotice": "{{count}}件の古いセグメントは表示省略（エクスポートには含まれます）"
     },
     "aiResponse": {
       "placeholder": "AIに質問すると、ここに回答が表示されます...",
@@ -116,6 +117,12 @@
       "incompatibleMessage": "お使いのブラウザは一部機能に対応していません。Chrome/Edge/Safari最新版をご利用ください。",
       "incompatibleButton": "⚠️ 非対応ブラウザ",
       "incompatibleTooltip": "以下の機能が使用できません: {features}"
+    },
+    "error": {
+      "fatalTitle": "エラーが発生しました",
+      "fatalBody": "予期しないエラーが発生しました。録音中の場合は自動停止されました。",
+      "resetSession": "セッションをリセット",
+      "reloadPage": "ページを再読み込み"
     }
   },
   "config": {
@@ -130,6 +137,15 @@
       "httpsOnly": "API呼び出し時のみHTTPS経由で送信",
       "isolated": "他のWebサイトからはアクセス不可",
       "exportable": "設定のエクスポート/インポート対応"
+    },
+    "storage": {
+      "migrationTitle": "APIキー保存方式が変わりました",
+      "migrationBody": "安全性向上のため、APIキーは通常セッション内のみ保持されます。次回からどうしますか？",
+      "sessionOnly": "セッションのみ（推奨）",
+      "persistKeys": "端末に保存する",
+      "persistLabel": "APIキーを次回も保持する（非推奨）",
+      "persistWarning": "共有端末では推奨しません。ブラウザにキーが残ります。",
+      "sessionNotice": "このキーはタブを閉じると消えます"
     },
     "stt": {
       "title": "文字起こし（STT）- プロバイダー選択",

--- a/vendor/THIRD_PARTY_NOTICES.md
+++ b/vendor/THIRD_PARTY_NOTICES.md
@@ -6,7 +6,8 @@ This folder contains third-party libraries distributed with this application.
 
 - **Version**: 5.4.530
 - **License**: Apache License 2.0
-- **Source**: https://github.com/nicolo-ribaudo/nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-nicolo-mozilla/pdf.js
+- **Source (upstream)**: https://github.com/mozilla/pdf.js
+- **Distribution**: https://www.npmjs.com/package/pdfjs-dist
 - **Files**: `pdfjs/pdf.min.mjs`, `pdfjs/pdf.worker.min.mjs`
 
 ```
@@ -40,3 +41,11 @@ modification, are permitted provided that the following conditions are met:
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
 ```
+
+---
+
+## How to Update Vendor Libraries
+
+1. **pdf.js**: Download `pdf.min.mjs` and `pdf.worker.min.mjs` from [pdfjs-dist npm](https://www.npmjs.com/package/pdfjs-dist) or build from source. Update version number above.
+2. **mammoth**: Download `mammoth.browser.min.js` from [mammoth.js releases](https://github.com/mwilliamson/mammoth.js/releases). Update version number above.
+3. After updating, verify the app loads and extracts PDF/DOCX files correctly.


### PR DESCRIPTION
## Summary

This PR implements the quality sprint focusing on stability and security improvements:

### P1 Fixes
- **#42**: Fix THIRD_PARTY_NOTICES vendor provenance (add Distribution line for pdfjs-dist)
- **#43**: Add minimal CI workflow with JS syntax and JSON validity checks
- **#44**: Cap transcript DOM rendering to 200 chunks with requestAnimationFrame throttle
- **#33**: Fix duplicate event bindings with `data-bound` attribute guards
- **#32**: Fix duplicate mic stream by passing existing MediaStream to PCMStreamProcessor
- **#36**: Harden `SecureStorage.getOption()` against invalid JSON with try/catch

### P0 Features
- **#41**: Session-only API keys by default
  - Migration modal shown once for existing localStorage keys
  - Optional `persistApiKeys` toggle in config.html
  - Keys move between sessionStorage/localStorage based on preference
  - Export/import respects storage preference
  
- **#40**: Global error handling and recovery UI
  - `window.onerror` and `window.onunhandledrejection` handlers
  - Fatal error modal with "Reset Session" and "Reload Page" buttons
  - `sanitizeErrorLog()` redacts API key patterns (sk-*, AIza*, dg_*, hashes)
  - Safe recording cleanup on fatal error

## Manual Test Checklist

### #41 Session-only Keys
- [ ] Migration modal appears once when legacy localStorage keys exist
- [ ] "セッションのみ（推奨）" moves keys from localStorage → sessionStorage
- [ ] `persistApiKeys` toggle in config moves keys between storages
- [ ] Export includes `options.persistApiKeys`
- [ ] Import respects `persistApiKeys` setting

### #40 Fatal Error Modal
- [ ] `Promise.reject(new Error("sk-FAKEFAKE..."))` triggers modal with redacted log
- [ ] Error during recording triggers cleanup + modal
- [ ] "Reset Session" clears transcript/AI response
- [ ] "Reload Page" reloads the page

## Files Changed
- `.github/workflows/ci.yml` (new)
- `vendor/THIRD_PARTY_NOTICES.md`
- `js/app.js` (error handlers, transcript cap, event binding guards, migration modal)
- `js/audio/pcm_stream.js` (accept existing MediaStream)
- `js/secure-storage.js` (session-only storage, migration functions)
- `js/config.js` (persistApiKeys toggle handler)
- `config.html` (persistApiKeys toggle UI)
- `index.html` (migration modal, error modal, CSS)
- `locales/ja.json`, `locales/en.json` (new i18n keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)