### PR TITLE
chore(ci): add UI smoke check for static build

### DIFF
--- a/.github/workflows/ui-smoke.yml
+++ b/.github/workflows/ui-smoke.yml
@@ -1,0 +1,17 @@
+name: UI Smoke Check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  ui-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: node scripts/ui_smoke_check.mjs

--- a/docs/ui/SMOKE_CHECK.md
+++ b/docs/ui/SMOKE_CHECK.md
@@ -1,0 +1,45 @@
+# UI Smoke Check (Static)
+
+## Local launch
+
+```bash
+python3 -m http.server 8080
+```
+
+Open `http://localhost:8080/index.html`.
+
+## Style switch (Brutalism/Paper)
+
+```js
+localStorage.setItem("appStyle", "paper");
+location.reload();
+```
+
+```js
+localStorage.setItem("appStyle", "brutalism");
+location.reload();
+```
+
+## Dark mode
+
+```js
+localStorage.setItem("display_theme", "dark");
+location.reload();
+```
+
+```js
+localStorage.setItem("display_theme", "light");
+location.reload();
+```
+
+## UI toggles
+
+- Dark mode toggle: `#themeToggleBtn`
+
+## Minimum checks
+
+- Tabs render and switch correctly
+- Modal opens/closes and layout is intact
+- Mobile layout toggle does not break the header
+- Meeting mode layout is intact
+- Toast notification styling is intact

--- a/scripts/ui_smoke_check.mjs
+++ b/scripts/ui_smoke_check.mjs
@@ -1,0 +1,88 @@
+import fs from "fs";
+import path from "path";
+
+const repoRoot = process.cwd();
+const indexPath = path.join(repoRoot, "index.html");
+const themePath = path.join(repoRoot, "js", "theme.js");
+
+const errors = [];
+const oks = [];
+
+function readFileOrError(filePath, label) {
+  if (!fs.existsSync(filePath)) {
+    errors.push(`Missing ${label}: ${filePath}`);
+    return "";
+  }
+  return fs.readFileSync(filePath, "utf8");
+}
+
+const indexHtml = readFileOrError(indexPath, "index.html");
+const themeJs = readFileOrError(themePath, "js/theme.js");
+
+if (indexHtml) {
+  const hasThemeScript = /<script[^>]*\ssrc=["']js\/theme\.js["'][^>]*>/i.test(indexHtml);
+  if (hasThemeScript) {
+    oks.push("Found js/theme.js script tag");
+  } else {
+    errors.push("Missing <script src=\"js/theme.js\"> in index.html");
+  }
+
+  const hasStyleSwitcher = /<select[^>]*\sid=["']styleSwitcher["']/i.test(indexHtml);
+  if (hasStyleSwitcher) {
+    oks.push("Found #styleSwitcher select");
+  } else {
+    errors.push("Missing <select id=\"styleSwitcher\"> in index.html");
+  }
+
+  const hasDataStyle = /<html[^>]*\sdata-style=/i.test(indexHtml);
+  if (hasDataStyle) {
+    oks.push("Found data-style on <html>");
+  } else {
+    errors.push("Missing data-style attribute on <html>");
+  }
+
+  const compatSelectors = [
+    ".modal-overlay",
+    ".tab-content",
+    ".toast",
+    ".meeting-mode",
+    ".floating-stop-btn",
+  ];
+
+  const missingSelectors = compatSelectors.filter((selector) => !indexHtml.includes(selector));
+  if (missingSelectors.length === 0) {
+    oks.push("Found compat selectors in index.html CSS");
+  } else {
+    errors.push(`Missing compat selectors in index.html: ${missingSelectors.join(", ")}`);
+  }
+}
+
+if (themeJs) {
+  const hasAppStyle = /appStyle/.test(themeJs);
+  const hasDisplayTheme = /display_theme/.test(themeJs);
+
+  if (hasAppStyle) {
+    oks.push("Found appStyle reference in js/theme.js");
+  } else {
+    errors.push("Missing appStyle reference in js/theme.js");
+  }
+
+  if (hasDisplayTheme) {
+    oks.push("Found display_theme reference in js/theme.js");
+  } else {
+    errors.push("Missing display_theme reference in js/theme.js");
+  }
+}
+
+if (errors.length > 0) {
+  console.error("NG: UI smoke check failed");
+  for (const message of errors) {
+    console.error(`- ${message}`);
+  }
+  process.exit(1);
+}
+
+console.log("OK: UI smoke check passed");
+for (const message of oks) {
+  console.log(`- ${message}`);
+}


### PR DESCRIPTION
Summary:
Add a node-only UI smoke check for the static app to prevent regressions in the skin switcher and compat-layer selectors, without touching index.html/js/theme.js.

Testing:
node scripts/ui_smoke_check.mjs

Notes:
No package.json required; the workflow runs with Node only. The smoke check will fail if #styleSwitcher / html[data-style] / js/theme.js key names change, or if CSS is moved out of index.html.