### PR TITLE
Fix #47/#48: gate logs and session-only context

### DIFF
--- a/config.html
+++ b/config.html
@@ -733,6 +733,13 @@
           <input type="checkbox" id="clearOnClose">
           <label for="clearOnClose" data-i18n="config.options.clearOnClose">Auto-delete API keys when browser closes (for shared PCs)</label>
         </div>
+        <div class="checkbox-group">
+          <input type="checkbox" id="persistMeetingContext">
+          <label for="persistMeetingContext" data-i18n="config.options.persistMeetingContext">Persist meeting context across sessions (not recommended)</label>
+        </div>
+        <div class="setting-hint" style="font-size: 0.75rem; color: var(--text-secondary); margin-top: 0.25rem;" data-i18n="config.options.persistMeetingContextHint">
+          Not recommended on shared devices. Meeting context remains in this browser.
+        </div>
       </div>
 
       <div class="security-options" style="background: #eff6ff; border-color: #bfdbfe;">

--- a/index.html
+++ b/index.html
@@ -1247,6 +1247,7 @@
     </button>
   </div>
 
+  <script src="js/debug.js"></script>
   <script src="js/i18n.js"></script>
   <script src="js/theme.js"></script>
   <script src="js/secure-storage.js" defer></script>

--- a/js/config.js
+++ b/js/config.js
@@ -212,6 +212,10 @@ function loadSavedSettings() {
   // オプション
   document.getElementById('persistApiKeys').checked = SecureStorage.getOption('persistApiKeys', false);
   document.getElementById('clearOnClose').checked = SecureStorage.getOption('clearOnClose', false);
+  const persistMeetingContextEl = document.getElementById('persistMeetingContext');
+  if (persistMeetingContextEl) {
+    persistMeetingContextEl.checked = SecureStorage.getOption('persistMeetingContext', false);
+  }
   document.getElementById('costAlertEnabled').checked = SecureStorage.getOption('costAlertEnabled', true);
   document.getElementById('costLimit').value = SecureStorage.getOption('costLimit', 100);
   document.getElementById('llmPriority').value = SecureStorage.getOption('llmPriority', 'auto');
@@ -296,6 +300,10 @@ async function saveSettings() {
   }
   SecureStorage.setOption('persistApiKeys', newPersistValue);
   SecureStorage.setOption('clearOnClose', document.getElementById('clearOnClose').checked);
+  const persistMeetingContextEl = document.getElementById('persistMeetingContext');
+  if (persistMeetingContextEl) {
+    SecureStorage.setOption('persistMeetingContext', persistMeetingContextEl.checked);
+  }
   SecureStorage.setOption('costAlertEnabled', document.getElementById('costAlertEnabled').checked);
   SecureStorage.setOption('costLimit', parseInt(document.getElementById('costLimit').value) || 100);
   SecureStorage.setOption('llmPriority', document.getElementById('llmPriority').value);

--- a/js/debug.js
+++ b/js/debug.js
@@ -1,0 +1,17 @@
+(function() {
+  const params = new URLSearchParams(window.location.search);
+  const enabled = (typeof window.DEBUG_LOGS === 'boolean')
+    ? window.DEBUG_LOGS
+    : (params.has('debug') || params.get('debug') === '1' || params.get('debug') === 'true');
+
+  window.DEBUG_LOGS = enabled;
+  window.debugLog = function(...args) {
+    if (window.DEBUG_LOGS) console.log(...args);
+  };
+  window.debugWarn = function(...args) {
+    if (window.DEBUG_LOGS) console.warn(...args);
+  };
+  window.debugInfo = function(...args) {
+    if (window.DEBUG_LOGS) console.info(...args);
+  };
+})();

--- a/js/secure-storage.js
+++ b/js/secure-storage.js
@@ -143,7 +143,8 @@ const SecureStorage = {
         sttProvider: this.getOption('sttProvider', 'openai_stt'),
         sttUserDictionary: this.getOption('sttUserDictionary', ''),
         sttLanguage: this.getOption('sttLanguage', 'ja'),
-        persistApiKeys: this.getOption('persistApiKeys', false)
+        persistApiKeys: this.getOption('persistApiKeys', false),
+        persistMeetingContext: this.getOption('persistMeetingContext', false)
       },
       exportedAt: new Date().toISOString()
     };
@@ -210,6 +211,7 @@ const SecureStorage = {
         if (data.options.sttLanguage) this.setOption('sttLanguage', data.options.sttLanguage);
         // Import persistApiKeys setting (defaults to false if not in export)
         this.setOption('persistApiKeys', data.options.persistApiKeys || false);
+        this.setOption('persistMeetingContext', data.options.persistMeetingContext || false);
         this.setMigrationDone(); // Mark as done since user imported settings
       }
 
@@ -237,6 +239,7 @@ const SecureStorage = {
     localStorage.removeItem('_opt_sttUserDictionary');
     localStorage.removeItem('_opt_sttLanguage');
     localStorage.removeItem('_opt_persistApiKeys');
+    localStorage.removeItem('_opt_persistMeetingContext');
     localStorage.removeItem('_apiKeyStorageMigrationDone');
   },
 

--- a/js/stt/providers/openai_chunked.js
+++ b/js/stt/providers/openai_chunked.js
@@ -56,7 +56,7 @@ class OpenAIChunkedProvider {
     }
     this.isActive = true;
     this.updateStatus('ready');
-    console.log('[OpenAI STT] Provider started');
+    debugLog('[OpenAI STT] Provider started');
   }
 
   /**
@@ -65,7 +65,7 @@ class OpenAIChunkedProvider {
   async stop() {
     this.isActive = false;
     this.updateStatus('stopped');
-    console.log('[OpenAI STT] Provider stopped');
+    debugLog('[OpenAI STT] Provider stopped');
   }
 
   /**
@@ -90,7 +90,7 @@ class OpenAIChunkedProvider {
     }
     const prompt = promptParts.join(' ');
 
-    console.log('[OpenAI STT] Transcribing blob:', {
+    debugLog('[OpenAI STT] Transcribing blob:', {
       size: audioBlob.size,
       type: audioBlob.type,
       model: this.model,
@@ -109,7 +109,7 @@ class OpenAIChunkedProvider {
       // promptパラメータを追加（空でない場合のみ）
       if (prompt) {
         formData.append('prompt', prompt);
-        console.log('[OpenAI STT] Using prompt:', prompt.substring(0, 100) + (prompt.length > 100 ? '...' : ''));
+        debugLog('[OpenAI STT] Using prompt:', prompt.substring(0, 100) + (prompt.length > 100 ? '...' : ''));
       }
 
       const response = await fetch('https://api.openai.com/v1/audio/transcriptions', {

--- a/locales/en.json
+++ b/locales/en.json
@@ -219,6 +219,8 @@
       "title": "Options",
       "securityTitle": "Security Options",
       "clearOnClose": "Auto-delete API keys when browser closes (for shared PCs)",
+      "persistMeetingContext": "Persist meeting context across sessions (not recommended)",
+      "persistMeetingContextHint": "Not recommended on shared devices. Meeting context remains in this browser.",
       "costAlertTitle": "Cost Alert",
       "costLimit": "Session cost limit (JPY)",
       "costLimitPlaceholder": "e.g. 100",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -218,6 +218,8 @@
       "title": "オプション設定",
       "securityTitle": "セキュリティオプション",
       "clearOnClose": "ブラウザを閉じたらAPIキーを自動削除（共有PC向け）",
+      "persistMeetingContext": "会議情報を次回も保持する（非推奨）",
+      "persistMeetingContextHint": "共有PCでは非推奨です。会議情報がこのブラウザに残ります。",
       "costAlertTitle": "コストアラート",
       "costLimit": "1セッションの上限金額（円）",
       "costLimitPlaceholder": "例: 100",


### PR DESCRIPTION
## Summary\n- Gate sensitive transcript/prompt/Q&A logs behind ?debug\n- Default meeting context persistence to sessionStorage with opt-in toggle and migration\n- Update settings UI + export/import/clearAll and i18n\n\n## Manual checks\n- Open index.html (no ?debug): no transcript/prompt/Q&A logs\n- Open index.html?debug=1: logs appear\n- Save meeting context -> sessionStorage only by default\n- Toggle Persist meeting context ON -> localStorage, OFF -> removed\n\nCloses #47\nCloses #48\n
