### PR TITLE
Fix #48: meetingContext session-by-default + legacy key migration

### DIFF
--- a/config.html
+++ b/config.html
@@ -733,6 +733,13 @@
           <input type="checkbox" id="clearOnClose">
           <label for="clearOnClose" data-i18n="config.options.clearOnClose">Auto-delete API keys when browser closes (for shared PCs)</label>
         </div>
+        <div class="checkbox-group">
+          <input type="checkbox" id="persistMeetingContext">
+          <label for="persistMeetingContext" data-i18n="config.options.persistMeetingContext">Persist meeting context across sessions (not recommended)</label>
+        </div>
+        <div class="setting-hint" style="font-size: 0.75rem; color: var(--text-secondary); margin-top: 0.25rem;" data-i18n="config.options.persistMeetingContextHint">
+          Not recommended on shared devices. Meeting context remains in this browser.
+        </div>
       </div>
 
       <div class="security-options" style="background: #eff6ff; border-color: #bfdbfe;">

--- a/js/config.js
+++ b/js/config.js
@@ -212,6 +212,10 @@ function loadSavedSettings() {
   // オプション
   document.getElementById('persistApiKeys').checked = SecureStorage.getOption('persistApiKeys', false);
   document.getElementById('clearOnClose').checked = SecureStorage.getOption('clearOnClose', false);
+  const persistMeetingContextEl = document.getElementById('persistMeetingContext');
+  if (persistMeetingContextEl) {
+    persistMeetingContextEl.checked = SecureStorage.getOption('persistMeetingContext', false);
+  }
   document.getElementById('costAlertEnabled').checked = SecureStorage.getOption('costAlertEnabled', true);
   document.getElementById('costLimit').value = SecureStorage.getOption('costLimit', 100);
   document.getElementById('llmPriority').value = SecureStorage.getOption('llmPriority', 'auto');
@@ -296,6 +300,10 @@ async function saveSettings() {
   }
   SecureStorage.setOption('persistApiKeys', newPersistValue);
   SecureStorage.setOption('clearOnClose', document.getElementById('clearOnClose').checked);
+  const persistMeetingContextEl = document.getElementById('persistMeetingContext');
+  if (persistMeetingContextEl) {
+    SecureStorage.setOption('persistMeetingContext', persistMeetingContextEl.checked);
+  }
   SecureStorage.setOption('costAlertEnabled', document.getElementById('costAlertEnabled').checked);
   SecureStorage.setOption('costLimit', parseInt(document.getElementById('costLimit').value) || 100);
   SecureStorage.setOption('llmPriority', document.getElementById('llmPriority').value);

--- a/js/secure-storage.js
+++ b/js/secure-storage.js
@@ -143,7 +143,8 @@ const SecureStorage = {
         sttProvider: this.getOption('sttProvider', 'openai_stt'),
         sttUserDictionary: this.getOption('sttUserDictionary', ''),
         sttLanguage: this.getOption('sttLanguage', 'ja'),
-        persistApiKeys: this.getOption('persistApiKeys', false)
+        persistApiKeys: this.getOption('persistApiKeys', false),
+        persistMeetingContext: this.getOption('persistMeetingContext', false)
       },
       exportedAt: new Date().toISOString()
     };
@@ -210,6 +211,7 @@ const SecureStorage = {
         if (data.options.sttLanguage) this.setOption('sttLanguage', data.options.sttLanguage);
         // Import persistApiKeys setting (defaults to false if not in export)
         this.setOption('persistApiKeys', data.options.persistApiKeys || false);
+        this.setOption('persistMeetingContext', data.options.persistMeetingContext || false);
         this.setMigrationDone(); // Mark as done since user imported settings
       }
 
@@ -237,6 +239,7 @@ const SecureStorage = {
     localStorage.removeItem('_opt_sttUserDictionary');
     localStorage.removeItem('_opt_sttLanguage');
     localStorage.removeItem('_opt_persistApiKeys');
+    localStorage.removeItem('_opt_persistMeetingContext');
     localStorage.removeItem('_apiKeyStorageMigrationDone');
   },
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -219,6 +219,8 @@
       "title": "Options",
       "securityTitle": "Security Options",
       "clearOnClose": "Auto-delete API keys when browser closes (for shared PCs)",
+      "persistMeetingContext": "Persist meeting context across sessions (not recommended)",
+      "persistMeetingContextHint": "Not recommended on shared devices. Meeting context remains in this browser.",
       "costAlertTitle": "Cost Alert",
       "costLimit": "Session cost limit (JPY)",
       "costLimitPlaceholder": "e.g. 100",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -218,6 +218,8 @@
       "title": "オプション設定",
       "securityTitle": "セキュリティオプション",
       "clearOnClose": "ブラウザを閉じたらAPIキーを自動削除（共有PC向け）",
+      "persistMeetingContext": "会議情報を次回も保持する（非推奨）",
+      "persistMeetingContextHint": "共有PCでは非推奨です。会議情報がこのブラウザに残ります。",
       "costAlertTitle": "コストアラート",
       "costLimit": "1セッションの上限金額（円）",
       "costLimitPlaceholder": "例: 100",


### PR DESCRIPTION
## Summary\n- persistMeetingContext OFFはsessionStorage、ONはlocalStorage\n- __meetingContext/_meetingContext両対応で正規化＆掃除\n\n## Manual checks\n1) サイトデータ消去 → Persist OFF → 会議情報保存 → sessionStorageに _meetingContext、localStorageは空\n2) Persist ON → localStorageに _meetingContext、sessionStorageは空\n3) Persist OFFに戻す → localStorageから削除されsessionStorageへ\n4) 旧データ（localStorage.__meetingContext）があっても初回ロードで正規化される\n\nCloses #48\n