### PR TITLE
chore(ci): add package.json for reproducible Playwright tests

### DIFF
--- a/.github/workflows/model-registry-test.yml
+++ b/.github/workflows/model-registry-test.yml
@@ -15,16 +15,16 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: |
-          npm install -g serve
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install --no-save playwright
+          npm ci
           npx playwright install chromium --with-deps
 
       - name: Start local server
         run: |
-          serve -l 3000 &
+          python3 -m http.server 3000 &
           # Wait for server to be ready (up to 30 seconds)
           for i in {1..30}; do
             if curl -s http://localhost:3000/index.html > /dev/null 2>&1; then

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 .serena/
 .DS_Store
 node_modules/
-package-lock.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,60 @@
+{
+  "name": "ai-meeting-assistant",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ai-meeting-assistant",
+      "devDependencies": {
+        "playwright": "^1.50.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
+      "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
+      "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "ai-meeting-assistant",
+  "private": true,
+  "description": "CI dependencies for smoke tests",
+  "devDependencies": {
+    "playwright": "^1.50.0"
+  }
+}


### PR DESCRIPTION
## Summary

Closes #63

Improves CI reproducibility and performance by adding proper npm dependency management.

## Changes

| File | Change |
|------|--------|
| `package.json` | Add with `playwright` as devDependency |
| `package-lock.json` | Commit for reproducible installs |
| `.gitignore` | Remove `package-lock.json` exclusion |
| `.github/workflows/model-registry-test.yml` | Update to use `npm ci` + caching |

## CI Improvements

- **Reproducibility**: `npm ci` uses lockfile for exact versions
- **Speed**: `actions/setup-node` caches npm dependencies
- **Fewer dependencies**: Replace `serve` with `python3 -m http.server`

## Before/After

```yaml
# Before
npm install -g serve
PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install --no-save playwright
npx playwright install chromium --with-deps
serve -l 3000 &

# After
npm ci
npx playwright install chromium --with-deps
python3 -m http.server 3000 &
```

## Test plan

- [ ] CI workflow runs successfully
- [ ] All 8 smoke tests pass
- [ ] npm cache is utilized on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)