### PR TITLE
Skip zero-height mobile bar measurements and broaden clamp warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,6 +188,11 @@
     html{color-scheme:light dark;}
 
     /* Phase 1: 100vh Fixed Layout */
+    :root { --app-h: 100vh; }
+    @supports (height: 100dvh) {
+      :root { --app-h: 100dvh; }
+    }
+
     html, body {
       height: 100vh;
       overflow: hidden;
@@ -207,7 +212,7 @@
     @media (max-width: 767px) {
       html, body {
         height: auto;
-        min-height: 100vh;
+        min-height: var(--app-h);
         overflow: auto;
       }
     }
@@ -222,7 +227,7 @@
     @media (max-width: 767px) {
       .app-wrapper {
         height: auto;
-        min-height: 100vh;
+        min-height: var(--app-h);
       }
     }
 
@@ -903,7 +908,7 @@
 
     /* ===== Mobile main tabs ===== */
     .main-tabs{ display:none; }
-    @media (max-width:1024px){
+    @media (min-width: 768px) and (max-width: 1024px){
       .main-tabs{
         display:flex;
         background:var(--card-bg);
@@ -1397,9 +1402,11 @@
         right: 0;
         bottom: 0;
         bottom: env(safe-area-inset-bottom, 0);
+        top: auto;
         z-index: 1200;
         background: var(--card-bg);
         border-top: var(--border-width) solid var(--border-color);
+        border-bottom: none;
         padding: 0.35rem 0.5rem calc(env(safe-area-inset-bottom, 0px) + 0.35rem);
         display: flex;
         justify-content: space-around;

--- a/js/app.js
+++ b/js/app.js
@@ -6198,13 +6198,27 @@ function syncMobileBarHeights() {
 
   const header = document.querySelector('.header');
   const mainTabs = document.querySelector('.main-tabs');
+  const warnIfClamped = (target, raw, clamped, min, max) => {
+    if ((raw < min || raw > max) && window.location.search.includes('debug')) {
+      console.warn('[mobile-bars] suspicious height clamp', { target, raw, clamped });
+    }
+  };
+
   if (header) {
-    const h = Math.ceil(header.getBoundingClientRect().height);
-    document.documentElement.style.setProperty('--mobile-topbar-h', `${h}px`);
+    const raw = Math.ceil(header.getBoundingClientRect().height);
+    if (raw > 0) {
+      const clamped = Math.min(Math.max(raw, 44), 140);
+      warnIfClamped('top', raw, clamped, 44, 140);
+      document.documentElement.style.setProperty('--mobile-topbar-h', `${clamped}px`);
+    }
   }
   if (mainTabs) {
-    const h = Math.ceil(mainTabs.getBoundingClientRect().height);
-    document.documentElement.style.setProperty('--mobile-bottombar-h', `${h}px`);
+    const raw = Math.ceil(mainTabs.getBoundingClientRect().height);
+    if (raw > 0) {
+      const clamped = Math.min(Math.max(raw, 44), 140);
+      warnIfClamped('bottom', raw, clamped, 44, 140);
+      document.documentElement.style.setProperty('--mobile-bottombar-h', `${clamped}px`);
+    }
   }
 }
 


### PR DESCRIPTION
### Motivation

- Prevent accidental overwrites of mobile bar CSS vars when an element is hidden or not laid out (measured height `0`) which previously forced a fallback `44px` value.
- Make debug diagnostics more useful by warning on both too-small and too-large measurements when `?debug` is present.

### Description

- Update `warnIfClamped` to accept `min` and `max` and to `console.warn` when `raw < min || raw > max` only if the URL contains `?debug`.
- Guard updates so measurements with `raw <= 0` are skipped and do not mutate the CSS variables, preserving the previous value.
- When valid, clamp measured heights with `const clamped = Math.min(Math.max(raw, 44), 140)` and set `--mobile-topbar-h` and `--mobile-bottombar-h` accordingly.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ffae804d8832fac2120bab3935702)