### PR TITLE
fix(mobile): iOS Safari bottom tab tap issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -1418,6 +1418,11 @@
         max-width: 240px;
         text-align: center;
         padding: 0.6rem 0.5rem;
+        touch-action: manipulation;
+      }
+      /* 内側要素がタップターゲットを奪うのを防ぐ（iOS Safari対策） */
+      .main-tab * {
+        pointer-events: none;
       }
 
       .app-wrapper {

--- a/js/app.js
+++ b/js/app.js
@@ -1175,14 +1175,26 @@ document.addEventListener('DOMContentLoaded', async function() {
   }
 
   // Phase 3: メインパネル切り替えタブ（スマホ用）
-  document.querySelectorAll('.main-tab[data-main-tab]').forEach(tab => {
-    tab.addEventListener('click', () => {
-      const tabName = tab.getAttribute('data-main-tab');
+  // イベント委譲 + closest() で内側のSPANタップにも対応（iOS Safari対策）
+  const mainTabsBar = document.querySelector('.main-tabs');
+  if (mainTabsBar) {
+    const onMainTabActivate = (e) => {
+      const btn = e.target?.closest?.('.main-tab');
+      if (!btn) return;
+      e.preventDefault();
+      const tabName = btn.dataset.mainTab;
       if (tabName) {
         switchMainTab(tabName);
       }
-    });
-  });
+    };
+    // PointerEvent対応なら pointerup のみ、なければ click + touchend
+    if (window.PointerEvent) {
+      mainTabsBar.addEventListener('pointerup', onMainTabActivate);
+    } else {
+      mainTabsBar.addEventListener('click', onMainTabActivate);
+      mainTabsBar.addEventListener('touchend', onMainTabActivate, { passive: false });
+    }
+  }
 
   // Phase 5: 会議中モード
   const meetingModeToggle = document.getElementById('meetingModeToggle');


### PR DESCRIPTION
## Summary
- Fix #73: Bottom tabs (文字起こし / AI回答) not responding to taps on iOS Safari
- Root cause: Taps on inner SPAN elements didn't trigger the click handler bound to .main-tab
- Solution: Event delegation with closest() + pointer-events: none on inner elements

## Changes
- **JS**: Use event delegation on `.main-tabs` container with `closest('.main-tab')`
- **JS**: PointerEvent detection to avoid double-firing (pointerup vs click+touchend)
- **CSS**: Add `touch-action: manipulation` to `.main-tab`
- **CSS**: Add `pointer-events: none` to `.main-tab *` to prevent target capture

## Test plan
- [ ] iPhone Safari: Tap 📝文字起こし → panel switches
- [ ] iPhone Safari: Tap 💬AI回答 → panel switches  
- [ ] Tap on icon (SPAN) area → still works
- [ ] Debug HUD shows `Last: SPAN` but panel still switches

🤖 Generated with [Claude Code](https://claude.com/claude-code)