### PR TITLE
fix(mobile): hide STT chip to reduce header height (#74)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1214,22 +1214,10 @@
         display: none !important;
       }
 
-      /* STTステータスチップは維持（省スペース表示） */
-      #sttStatusChip {
-        font-size: 0.75rem;
-        padding: 0.25rem 0.5rem;
-      }
-
-      /* 展開時のSTT設定も圧縮 */
-      #headerSttControls.expanded {
-        flex-wrap: wrap;
-        gap: 0.5rem;
-      }
-
-      #headerSttControls select {
-        font-size: 0.75rem;
-        padding: 0.3rem 0.4rem;
-        min-width: 70px;
+      /* #74: mobile header compact - hide STT chip & expanded controls */
+      #sttStatusChip,
+      #headerSttControls {
+        display: none !important;
       }
 
       /* ===== ボタンラベルを隠してアイコンのみ（1行成立） ===== */


### PR DESCRIPTION
## Summary
- モバイル（<=767px）でSTTチップ（`#sttStatusChip`）と展開コントロール（`#headerSttControls`）を非表示に
- ヘッダーの縦幅を削減し、コンテンツエリアを確保

## Changes
- `index.html`: `@media (max-width: 767px)` セクションで `display: none !important` を適用
- 以前の「省スペース表示」スタイル（16行）を完全非表示（4行）に置換

## Verification Checklist
- [ ] iPhone縦持ち or DevTools (375x667) でヘッダーが1行に収まる
- [ ] 表示: 🎤録音 + ステータス + 🎯会議モード + ⋯その他
- [ ] 下タブ（文字起こし/AI回答）がタップ可能（#73回帰テスト）
- [ ] デスクトップ（>1024px）でSTTチップが表示・展開可能

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)