### PR TITLE
fix(config): sync API keys to opener tab when saving settings

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -788,6 +788,17 @@ document.addEventListener('DOMContentLoaded', async function() {
     updateLLMIndicator();
   });
 
+  // 設定画面（別タブ）からの設定変更通知を受信してUIを更新
+  window.addEventListener('message', function(e) {
+    // 同一オリジンからのメッセージのみ処理
+    if (e.origin !== window.location.origin) return;
+    if (e.data && e.data.type === 'settings-updated') {
+      console.log('[App] Settings updated from config tab, refreshing UI');
+      updateLLMIndicator();
+      updateLLMButtonsState();
+    }
+  });
+
   // ユーザー辞書を読み込み
   loadUserDictionary();
 


### PR DESCRIPTION
sessionStorage is isolated per tab, so when the settings page is opened in a new tab, API keys saved there were not available in the main tab.

This fix:
- Syncs API keys directly to the opener's sessionStorage when saving
- Sends a postMessage notification to trigger UI updates in the main tab
- Adds a message event listener in app.js to refresh the LLM buttons

https://claude.ai/code/session_017oa89KY2n9WmrLFgGFTbdG