### PR TITLE
i18n: localize timeline action tooltips

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -4077,10 +4077,10 @@ function renderTimelineItem(item) {
   const aiTypeLabel = item.aiType ? ` (${item.aiType})` : '';
 
   const memoActions = item.source === 'memo' ? `
-    <button class="btn-icon" data-action="pin" title="${item.pinned ? 'ピン解除' : 'ピン留め'}">📌</button>
-    ${item.type === 'memo' ? '<button class="btn-icon" data-action="to-todo" title="TODOに変換">☑️</button>' : ''}
-    ${item.type === 'todo' ? '<button class="btn-icon" data-action="toggle" title="完了切替">✓</button>' : ''}
-    <button class="btn-icon" data-action="delete" title="削除">🗑️</button>
+    <button class="btn-icon" data-action="pin" title="${item.pinned ? escapeHtml(t('app.timeline.actions.unpin') || 'ピン解除') : escapeHtml(t('app.timeline.actions.pin') || 'ピン留め')}">📌</button>
+    ${item.type === 'memo' ? `<button class="btn-icon" data-action="to-todo" title="${escapeHtml(t('app.timeline.actions.toTodo') || 'TODOに変換')}">☑️</button>` : ''}
+    ${item.type === 'todo' ? `<button class="btn-icon" data-action="toggle" title="${escapeHtml(t('app.timeline.actions.toggleComplete') || '完了切替')}">✓</button>` : ''}
+    <button class="btn-icon" data-action="delete" title="${escapeHtml(t('app.timeline.actions.delete') || '削除')}">🗑️</button>
   ` : '';
 
   return `

--- a/locales/en.json
+++ b/locales/en.json
@@ -95,7 +95,14 @@
       "filterAI": "AI",
       "filterQA": "Q&A",
       "searchPlaceholder": "Search keywords...",
-      "empty": "No items in timeline"
+      "empty": "No items in timeline",
+      "actions": {
+        "pin": "Pin",
+        "unpin": "Unpin",
+        "toTodo": "Convert to TODO",
+        "toggleComplete": "Toggle complete",
+        "delete": "Delete"
+      }
     },
     "details": {
       "toggle": "Details",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -95,7 +95,14 @@
       "filterAI": "AI",
       "filterQA": "Q&A",
       "searchPlaceholder": "キーワード検索...",
-      "empty": "タイムラインにアイテムがありません"
+      "empty": "タイムラインにアイテムがありません",
+      "actions": {
+        "pin": "ピン留め",
+        "unpin": "ピン解除",
+        "toTodo": "TODOに変換",
+        "toggleComplete": "完了切替",
+        "delete": "削除"
+      }
     },
     "details": {
       "toggle": "詳細設定",


### PR DESCRIPTION
### Motivation
- Replace hard-coded Japanese tooltips for timeline memo/TODO action buttons with i18n keys so the UI follows the selected locale and attributes are safely escaped.

### Description
- Use localized strings via `t('app.timeline.actions.*')` and `escapeHtml(...)` for the action `title` attributes in `renderTimelineItem` in `js/app.js` instead of hard-coded text.
- Add `app.timeline.actions` keys (`pin`, `unpin`, `toTodo`, `toggleComplete`, `delete`) to both `locales/ja.json` and `locales/en.json` to provide Japanese and English tooltips.
- Keep existing behavior of action handlers (`pin`, `to-todo`, `toggle`, `delete`) unchanged while improving UX and XSS safety for button titles.

### Testing
- Parsed both locale files successfully using `node -e "JSON.parse(require('fs').readFileSync('locales/ja.json','utf8')); JSON.parse(require('fs').readFileSync('locales/en.json','utf8'))"`, which succeeded.
- Ran documentation consistency checks with `bash scripts/check-docs-consistency.sh`, which passed all checks.
- Attempted Playwright/browser smoke tests via `npx playwright install chromium` and `node scripts/model-registry-smoke.mjs`, but those failed due to external network/403 errors preventing browser download, so UI smoke tests could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698579005828832f9a970daa464c1168)