### PR TITLE
feat(export): auto-embed AI-tagged memo instructions in AI Work Order

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -435,6 +435,7 @@
       "aiWorkOrderRuleEvidence": "For key decisions, include supporting evidence from this markdown.",
       "aiWorkOrderRuleOrder": "Keep the output order fixed and do not reorder sections.",
       "aiWorkOrderRuleQuestionFirst": "Show clarification questions first, then provide deliverables.",
+      "aiWorkOrderAdditionalTitle": "Additional Instructions",
       "aiWorkOrderOutputTitle": "Output Order",
       "aiWorkOrderOutputQuestions": "Clarification questions for missing information",
       "aiWorkOrderOutputDeliverables": "Deliverables",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -434,6 +434,7 @@
       "aiWorkOrderRuleEvidence": "重要な判断には、このMD内の根拠を引用して添える。",
       "aiWorkOrderRuleOrder": "出力順序は固定し、順番を変更しない。",
       "aiWorkOrderRuleQuestionFirst": "最初に確認質問を提示し、その後で成果物を提示する。",
+      "aiWorkOrderAdditionalTitle": "追加指示",
       "aiWorkOrderOutputTitle": "出力順序",
       "aiWorkOrderOutputQuestions": "不足情報の確認質問",
       "aiWorkOrderOutputDeliverables": "成果物",


### PR DESCRIPTION
## Summary\n- extract AI instruction lines from memo/todo content using markers: `【AI】`, `AI:`, and `@ai`\n- append extracted items to AI Work Order as `### 追加指示 / Additional Instructions`\n- remove extracted AI-instruction lines from regular memo/todo export sections to avoid duplication\n- add i18n labels for the new subsection (ja/en)\n\nFixes #90