### PR TITLE
feat: add sanitized diagnostic pack export for support

### DIFF
--- a/index.html
+++ b/index.html
@@ -2472,7 +2472,9 @@
       </div>
       <div class="modal-footer" style="justify-content:space-between;">
         <button class="btn btn-ghost" id="clearHistoryBtn">🧹 <span data-i18n="history.clearAll">履歴を全て削除</span></button>
-        <div style="display:flex; gap:0.5rem;">
+        <div style="display:flex; gap:0.5rem; flex-wrap:wrap; justify-content:flex-end;">
+          <button class="btn btn-secondary" id="copyDiagnosticPackBtn">🩺 <span data-i18n="history.diagnosticCopy">診断パックをコピー</span></button>
+          <button class="btn btn-secondary" id="downloadDiagnosticPackBtn">💾 <span data-i18n="history.diagnosticDownload">診断JSON保存</span></button>
           <button class="btn btn-secondary" id="importHistoryBtn">📂 <span data-i18n="history.import">MDファイルを読み込む</span></button>
           <input type="file" id="importFileInput" accept=".md,text/markdown" style="display:none;">
           <button class="btn btn-secondary" id="closeHistoryModalFooterBtn" data-i18n="common.close">閉じる</button>

--- a/locales/en.json
+++ b/locales/en.json
@@ -353,6 +353,11 @@
       "openedInNewTab": "Opened in new tab. Long-press or use share button to save",
       "copyFallback": "Popup blocked. Please copy from the preview"
     },
+    "diagnostic": {
+      "copied": "Diagnostic pack copied",
+      "downloaded": "Diagnostic JSON saved",
+      "failed": "Failed to generate diagnostic pack"
+    },
     "llm": {
       "notConfigured": "LLM API key not set. Please register an API key in settings."
     },
@@ -479,6 +484,10 @@
     "notSupported": "History is not available in this browser.",
     "missingRecord": "Record not found",
     "import": "Import MD file",
+    "diagnosticCopy": "Copy Diagnostic Pack",
+    "diagnosticDownload": "Save Diagnostic JSON",
+    "diagnosticTitle": "Diagnostic Pack",
+    "diagnosticDescription": "Paste the following into your issue body (no meeting text, audio, or API keys included)",
     "importConfirmOverwrite": "Overwrite current transcript and AI responses?",
     "importSuccess": "MD file imported successfully",
     "importFailed": "Failed to import MD file: {message}",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -352,6 +352,11 @@
       "openedInNewTab": "新しいタブで開きました。長押しまたは共有ボタンから保存できます",
       "copyFallback": "ポップアップがブロックされました。プレビューからコピーしてください"
     },
+    "diagnostic": {
+      "copied": "診断パックをコピーしました",
+      "downloaded": "診断JSONを保存しました",
+      "failed": "診断パックの出力に失敗しました"
+    },
     "llm": {
       "notConfigured": "LLM APIキーが未設定です。設定画面でAPIキーを登録してください。"
     },
@@ -478,6 +483,10 @@
     "notSupported": "このブラウザでは履歴機能を利用できません。",
     "missingRecord": "履歴が見つかりません",
     "import": "MDファイルを読み込む",
+    "diagnosticCopy": "診断パックをコピー",
+    "diagnosticDownload": "診断JSON保存",
+    "diagnosticTitle": "診断パック",
+    "diagnosticDescription": "以下をIssue本文に貼ってください（会議本文・音声・APIキーは含みません）",
     "importConfirmOverwrite": "現在の文字起こしとAI回答を上書きしますか？",
     "importSuccess": "MDファイルを読み込みました",
     "importFailed": "MDファイルの読み込みに失敗しました: {message}",


### PR DESCRIPTION
## Summary
- add a support-oriented diagnostic pack generator that excludes transcript/audio/API keys
- add one-click actions in history modal to copy issue-ready markdown and save diagnostic JSON
- include environment/provider/runtime metadata, recent error codes, and sanitized settings export

## Validation
- node --check js/app.js
- node --check js/file-extractor.js
- node -e "JSON.parse(require('fs').readFileSync('locales/ja.json','utf8')); JSON.parse(require('fs').readFileSync('locales/en.json','utf8')); console.log('locale json ok')"
- bash scripts/check-docs-consistency.sh

Fixes #87