### PR TITLE
feat: add one-click 30-sec demo meeting flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -1998,6 +1998,9 @@
         <button type="button" class="header-more-menu-item" data-action="export">
           📥 <span data-i18n="common.export">エクスポート</span>
         </button>
+        <button type="button" class="header-more-menu-item" data-action="demo">
+          ⚡ <span data-i18n="app.header.demo">30秒デモ</span>
+        </button>
         <button type="button" class="header-more-menu-item" data-action="history">
           📚 <span data-i18n="history.open">履歴</span>
         </button>
@@ -2385,6 +2388,7 @@
         </div>
       </div>
       <div class="modal-footer">
+        <button class="btn btn-ghost" id="loadDemoSessionBtn">⚡ <span data-i18n="modal.welcome.demoButton">30秒デモを試す</span></button>
         <button class="btn btn-secondary" id="skipWelcomeBtn" data-i18n="modal.welcome.skipButton">後で設定する</button>
         <a href="config.html" class="btn btn-primary">⚙️ <span data-i18n="modal.welcome.startButton">設定を開始する</span></a>
       </div>

--- a/locales/en.json
+++ b/locales/en.json
@@ -24,7 +24,8 @@
       "title": "AI Meeting Assistant",
       "settings": "Settings",
       "detailSettings": "Details",
-      "more": "More"
+      "more": "More",
+      "demo": "30-sec Demo"
     },
     "recording": {
       "start": "Start Recording",
@@ -513,6 +514,7 @@
       "feature3": "API keys are session-only and cleared on close",
       "feature4": "Real-time display of estimated usage costs",
       "terms": "By starting, you agree to the Terms of Service and Privacy Policy.",
+      "demoButton": "Try 30-sec Demo",
       "skipButton": "Configure later",
       "startButton": "Start Configuration"
     }
@@ -604,5 +606,11 @@
     "nativeDocsFallback": "Native Docs failed, falling back to text extraction",
     "badgeReasoningBoost": "Boost ON",
     "badgeNativeDocs": "Native Docs ON"
+  },
+  "demo": {
+    "overwriteConfirm": "Overwrite current content with demo data?",
+    "stopRecordingFirst": "Stop recording before loading demo data",
+    "loaded": "Demo meeting loaded",
+    "loadedAndOpenedExport": "Demo meeting loaded and export opened"
   }
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -24,7 +24,8 @@
       "title": "AI参加会議",
       "settings": "設定",
       "detailSettings": "詳細設定",
-      "more": "その他"
+      "more": "その他",
+      "demo": "30秒デモ"
     },
     "recording": {
       "start": "録音開始",
@@ -512,6 +513,7 @@
       "feature3": "APIキーはセッション内のみ保持",
       "feature4": "利用料金の概算をリアルタイム表示",
       "terms": "利用開始により、利用規約とプライバシーポリシーに同意したものとみなされます。",
+      "demoButton": "30秒デモを試す",
       "skipButton": "後で設定する",
       "startButton": "設定を開始する"
     }
@@ -603,5 +605,11 @@
     "nativeDocsFallback": "Native Docsに失敗、テキスト抽出にフォールバック",
     "badgeReasoningBoost": "Boost ON",
     "badgeNativeDocs": "Native Docs ON"
+  },
+  "demo": {
+    "overwriteConfirm": "現在の内容をデモデータで上書きしますか？",
+    "stopRecordingFirst": "デモを読み込む前に録音を停止してください",
+    "loaded": "デモ会議を読み込みました",
+    "loadedAndOpenedExport": "デモ会議を読み込み、エクスポートを開きました"
   }
 }


### PR DESCRIPTION
## Summary
- add a one-click demo session loader for first-time users (welcome modal + more menu)
- preload transcript/memos/todo/AI responses so users can try export immediately
- auto-open export modal after demo load to complete demo -> export -> AI work order flow

## Validation
- node --check js/app.js
- node -e "JSON.parse(require('fs').readFileSync('locales/ja.json','utf8')); JSON.parse(require('fs').readFileSync('locales/en.json','utf8')); console.log('locale json ok')"
- bash scripts/check-docs-consistency.sh

Fixes #95