### PR TITLE
chore: READMEバッジv1.4.0同期 + i18nキーチェッカー追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
           done
           echo "All JSON files are valid"
 
+      - name: Check i18n locale key completeness
+        run: node scripts/check-i18n-keys.mjs
+
       - name: Check required docs exist
         run: |
           echo "Checking required documentation..."

--- a/README.en.md
+++ b/README.en.md
@@ -2,7 +2,7 @@
 
 [🇯🇵 日本語](README.md) | 🇺🇸 English
 
-[![Version](https://img.shields.io/badge/version-v1.3.0-blue)](https://github.com/gatyoukatyou/ai-meeting-assistant/releases/tag/v1.3.0)
+[![Version](https://img.shields.io/badge/version-v1.4.0-blue)](https://github.com/gatyoukatyou/ai-meeting-assistant/releases/tag/v1.4.0)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
 A lightweight, browser-based meeting assistant that records audio, transcribes speech, and generates summaries, consult responses, minutes, and memos using AI.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 🇯🇵 日本語 | [🇺🇸 English](README.en.md)
 
-[![Version](https://img.shields.io/badge/version-v1.3.0-blue)](https://github.com/gatyoukatyou/ai-meeting-assistant/releases/tag/v1.3.0)
+[![Version](https://img.shields.io/badge/version-v1.4.0-blue)](https://github.com/gatyoukatyou/ai-meeting-assistant/releases/tag/v1.4.0)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
 会議中にAIがリアルタイムで参加し、文字起こし・要約・相談・議事録・メモを行うWebアプリです。

--- a/locales/en.json
+++ b/locales/en.json
@@ -244,7 +244,6 @@
       "priorityGroq": "Prefer Groq",
       "priorityHint": "Auto-select order: Claude → OpenAI → Gemini → Groq (uses first available)",
       "notConfiguredWarning": "If no LLM API key is set, AI features like summary, opinion, and minutes will not be available. Please configure at least one above.",
-      "notConfiguredTitle": "If no LLM API key is set",
       "getFromGemini": "Get from Google AI Studio (for summary/AI responses)",
       "getFromClaude": "Get from Anthropic Console",
       "getFromOpenAILLM": "Get from OpenAI Platform (separate key from STT recommended)",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "CI dependencies for smoke tests",
   "scripts": {
     "test:generate": "node scripts/generate-test-files.mjs",
+    "test:i18n": "node scripts/check-i18n-keys.mjs",
     "test:ui-smoke": "node scripts/ui_smoke_check.mjs",
     "test:model-registry": "node scripts/model-registry-smoke.mjs",
     "test:upload-basic": "node scripts/test-upload-basic.mjs",

--- a/scripts/check-i18n-keys.mjs
+++ b/scripts/check-i18n-keys.mjs
@@ -1,0 +1,87 @@
+/**
+ * i18n locale key completeness checker
+ *
+ * Compares all locale JSON files against the reference locale (ja.json)
+ * and reports missing or extra keys at every nesting level.
+ *
+ * Run: node scripts/check-i18n-keys.mjs
+ * Exit code: 0 = all locales in sync, 1 = mismatches found
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const LOCALES_DIR = path.join(__dirname, '..', 'locales');
+const REFERENCE_LOCALE = 'ja';
+
+function flattenKeys(obj, prefix = '') {
+  const keys = [];
+  for (const [key, value] of Object.entries(obj)) {
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      keys.push(...flattenKeys(value, fullKey));
+    } else {
+      keys.push(fullKey);
+    }
+  }
+  return keys;
+}
+
+function loadLocale(name) {
+  const filePath = path.join(LOCALES_DIR, `${name}.json`);
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+function main() {
+  console.log('Checking i18n locale key completeness...\n');
+
+  const files = readdirSync(LOCALES_DIR).filter(f => f.endsWith('.json'));
+  const localeNames = files.map(f => f.replace('.json', ''));
+
+  if (!localeNames.includes(REFERENCE_LOCALE)) {
+    console.error(`Reference locale "${REFERENCE_LOCALE}.json" not found`);
+    process.exit(1);
+  }
+
+  const refData = loadLocale(REFERENCE_LOCALE);
+  const refKeys = new Set(flattenKeys(refData));
+
+  console.log(`Reference: ${REFERENCE_LOCALE}.json (${refKeys.size} keys)`);
+
+  let hasErrors = false;
+
+  for (const name of localeNames) {
+    if (name === REFERENCE_LOCALE) continue;
+
+    const data = loadLocale(name);
+    const keys = new Set(flattenKeys(data));
+
+    const missing = [...refKeys].filter(k => !keys.has(k));
+    const extra = [...keys].filter(k => !refKeys.has(k));
+
+    if (missing.length === 0 && extra.length === 0) {
+      console.log(`  \x1b[32m\u2713\x1b[0m ${name}.json (${keys.size} keys) — in sync`);
+    } else {
+      hasErrors = true;
+      console.log(`  \x1b[31m\u2717\x1b[0m ${name}.json (${keys.size} keys) — mismatches found`);
+      for (const k of missing) {
+        console.log(`      MISSING: ${k}`);
+      }
+      for (const k of extra) {
+        console.log(`      EXTRA:   ${k}`);
+      }
+    }
+  }
+
+  console.log('');
+  if (hasErrors) {
+    console.log('i18n key check FAILED — locales are out of sync');
+    process.exit(1);
+  } else {
+    console.log('i18n key check passed — all locales in sync');
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

- README.md / README.en.md のバージョンバッジを v1.3.0 → v1.4.0 に更新（CHANGELOG と同期）
- `scripts/check-i18n-keys.mjs` を新設 — ja.json を基準に全ロケールのキー完全性を検証
- `en.json` の孤立キー `config.llm.notConfiguredTitle`（コード未使用）を削除
- CI (`ci.yml`) に i18n キーチェック step を追加
- `package.json` に `test:i18n` スクリプトを追加

## Changes

| File | Action | Details |
|------|--------|---------|
| `README.md` | MODIFY | バッジ v1.3.0 → v1.4.0 |
| `README.en.md` | MODIFY | 同上 |
| `locales/en.json` | MODIFY | 未使用キー `notConfiguredTitle` 削除 |
| `scripts/check-i18n-keys.mjs` | **CREATE** | i18n キー完全性チェッカー |
| `package.json` | MODIFY | `test:i18n` 追加 |
| `.github/workflows/ci.yml` | MODIFY | i18n チェック step 追加 |

## Test plan

- [x] `npm run test:i18n` が pass（485 keys, in sync）
- [ ] CI の lint ジョブで i18n チェックが実行される
- [ ] 既存の ci / e2e / ui-smoke / security ワークフローに影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)