### PR TITLE
refactor: extract FormatUtils (unit-tested)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,6 +27,7 @@ export default [
         AIMeetingTheme: 'writable',
         RecordingMonitor: 'writable',
         FileExtractor: 'writable',
+        FormatUtils: 'readonly',
         STTProviders: 'writable',
         PCMStreamProcessor: 'writable',
         AudioResampler: 'writable',

--- a/index.html
+++ b/index.html
@@ -2599,6 +2599,8 @@
   <script src="js/stt/providers/deepgram_ws.js" defer></script>
   <!-- ファイル抽出 -->
   <script src="js/file-extractor.js" defer></script>
+  <!-- フォーマットユーティリティ -->
+  <script src="js/lib/format-utils.js" defer></script>
   <!-- メインアプリ -->
   <script src="js/app.js" defer></script>
 </body>

--- a/js/app.js
+++ b/js/app.js
@@ -145,6 +145,12 @@ let qaEventLog = [];
 // Issue #40: Global error handling
 let errorHandlerActive = false;
 
+// --- Format utilities (delegated to js/lib/format-utils.js) ---
+var formatCost = FormatUtils.formatCost;
+var formatNumber = FormatUtils.formatNumber;
+var sanitizeFileName = FormatUtils.sanitizeFileName;
+var deepCopy = FormatUtils.deepCopy;
+
 // Sanitize error logs to remove potential API key leaks
 function sanitizeErrorLog(str) {
   if (typeof str !== 'string') return String(str);
@@ -3776,13 +3782,6 @@ function updateCosts() {
   syncChipValues();
 }
 
-function formatCost(yen) {
-  if (yen < 1) {
-    return `¥${yen.toFixed(2)}`;
-  }
-  return `¥${Math.round(yen).toLocaleString()}`;
-}
-
 function formatDuration(seconds) {
   if (seconds < 60) {
     return t('app.cost.seconds', { n: Math.round(seconds) });
@@ -3790,10 +3789,6 @@ function formatDuration(seconds) {
   const mins = Math.floor(seconds / 60);
   const secs = Math.round(seconds % 60);
   return t('app.cost.minSec', { min: mins, sec: secs });
-}
-
-function formatNumber(num) {
-  return num.toLocaleString();
 }
 
 function updateCostBadge(badge, cost) {
@@ -5129,19 +5124,6 @@ function getDefaultMeetingTitle(date = new Date()) {
   });
 }
 
-// ディープコピー用ヘルパー（structuredClone優先、フォールバックはJSON）
-function deepCopy(obj) {
-  if (obj === null || obj === undefined) return obj;
-  if (typeof structuredClone === 'function') {
-    try {
-      return structuredClone(obj);
-    } catch (e) {
-      // structuredCloneが失敗した場合はJSONフォールバック
-    }
-  }
-  return JSON.parse(JSON.stringify(obj));
-}
-
 function buildHistoryRecord() {
   if (typeof HistoryStore === 'undefined') return null;
   const transcriptText = getFilteredTranscriptText();
@@ -6128,11 +6110,6 @@ function truncateText(text, limit = 160) {
   const trimmed = text.trim();
   if (trimmed.length <= limit) return trimmed;
   return `${trimmed.slice(0, limit)}…`;
-}
-
-function sanitizeFileName(name) {
-  if (!name) return 'meeting';
-  return name.replace(/[<>:"/\\|?*\n\r]+/g, '').trim() || 'meeting';
 }
 
 // =====================================

--- a/js/lib/format-utils.js
+++ b/js/lib/format-utils.js
@@ -1,0 +1,39 @@
+// Pure formatting helpers — no DOM / i18n / global-state dependencies.
+// Consumed by app.js via thin aliases (e.g. var formatCost = FormatUtils.formatCost).
+const FormatUtils = (function () {
+  'use strict';
+
+  function formatCost(yen) {
+    if (yen < 1) {
+      return `¥${yen.toFixed(2)}`;
+    }
+    return `¥${Math.round(yen).toLocaleString()}`;
+  }
+
+  function formatNumber(num) {
+    return num.toLocaleString();
+  }
+
+  function sanitizeFileName(name) {
+    if (!name) return 'meeting';
+    return name.replace(/[<>:"/\\|?*\n\r]+/g, '').trim() || 'meeting';
+  }
+
+  function deepCopy(obj) {
+    if (obj === null || obj === undefined) return obj;
+    if (typeof structuredClone === 'function') {
+      try {
+        return structuredClone(obj);
+      } catch (e) {
+        // structuredCloneが失敗した場合はJSONフォールバック
+      }
+    }
+    return JSON.parse(JSON.stringify(obj));
+  }
+
+  return { formatCost, formatNumber, sanitizeFileName, deepCopy };
+})();
+
+if (typeof window !== 'undefined') {
+  window.FormatUtils = FormatUtils;
+}

--- a/tests/unit/format-utils.test.mjs
+++ b/tests/unit/format-utils.test.mjs
@@ -1,0 +1,114 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadScript } from '../helpers/load-script.mjs';
+
+const { FormatUtils } = loadScript('js/lib/format-utils.js');
+
+// ========================================
+// formatCost()
+// ========================================
+
+describe('formatCost', () => {
+  it('returns yen with 2 decimals for values < 1', () => {
+    assert.equal(FormatUtils.formatCost(0.5), '¥0.50');
+  });
+
+  it('returns yen with 2 decimals for very small values', () => {
+    assert.equal(FormatUtils.formatCost(0.01), '¥0.01');
+  });
+
+  it('rounds and returns integer yen for values >= 1', () => {
+    const result = FormatUtils.formatCost(10);
+    assert.equal(typeof result, 'string');
+    assert.ok(result.startsWith('¥'));
+    assert.ok(result.includes('10'));
+  });
+
+  it('formats large values with locale separators', () => {
+    const result = FormatUtils.formatCost(1234);
+    assert.equal(typeof result, 'string');
+    assert.ok(result.startsWith('¥'));
+    // Locale-dependent: might be "1,234" or "1.234" etc.
+    assert.ok(result.includes('1'));
+    assert.ok(result.includes('234'));
+  });
+});
+
+// ========================================
+// formatNumber()
+// ========================================
+
+describe('formatNumber', () => {
+  it('returns a locale string for an integer', () => {
+    const result = FormatUtils.formatNumber(1000);
+    assert.equal(typeof result, 'string');
+    assert.ok(result.includes('1'));
+    assert.ok(result.includes('000'));
+  });
+
+  it('returns "0" for zero', () => {
+    assert.equal(FormatUtils.formatNumber(0), '0');
+  });
+});
+
+// ========================================
+// sanitizeFileName()
+// ========================================
+
+describe('sanitizeFileName', () => {
+  it('returns a normal name unchanged', () => {
+    assert.equal(FormatUtils.sanitizeFileName('my-meeting'), 'my-meeting');
+  });
+
+  it('strips illegal filename characters', () => {
+    assert.equal(FormatUtils.sanitizeFileName('file<>:name'), 'filename');
+  });
+
+  it('returns "meeting" for empty string', () => {
+    assert.equal(FormatUtils.sanitizeFileName(''), 'meeting');
+  });
+
+  it('returns "meeting" for null', () => {
+    assert.equal(FormatUtils.sanitizeFileName(null), 'meeting');
+  });
+
+  it('returns "meeting" for whitespace-only after sanitization', () => {
+    assert.equal(FormatUtils.sanitizeFileName('   '), 'meeting');
+  });
+});
+
+// ========================================
+// deepCopy()
+// ========================================
+
+describe('deepCopy', () => {
+  it('deep-copies a plain object', () => {
+    const original = { a: 1, b: { c: 2 } };
+    const copy = FormatUtils.deepCopy(original);
+    // Cross-realm structuredClone objects may fail deepStrictEqual; compare via JSON
+    assert.equal(JSON.stringify(copy), JSON.stringify(original));
+    assert.notEqual(copy, original);
+  });
+
+  it('deep-copies an array', () => {
+    const original = [1, [2, 3]];
+    const copy = FormatUtils.deepCopy(original);
+    assert.equal(JSON.stringify(copy), JSON.stringify(original));
+    assert.notEqual(copy, original);
+  });
+
+  it('returns null for null input', () => {
+    assert.equal(FormatUtils.deepCopy(null), null);
+  });
+
+  it('returns undefined for undefined input', () => {
+    assert.equal(FormatUtils.deepCopy(undefined), undefined);
+  });
+
+  it('does not affect original when copy is mutated', () => {
+    const original = { x: { y: 1 } };
+    const copy = FormatUtils.deepCopy(original);
+    copy.x.y = 999;
+    assert.equal(original.x.y, 1);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract 4 pure helpers (`formatCost`, `formatNumber`, `sanitizeFileName`, `deepCopy`) from `app.js` into `js/lib/format-utils.js` (IIFE `FormatUtils` module)
- Keep all `app.js` call sites unchanged via thin `var` aliases
- Load `format-utils.js` before `app.js` in `index.html` (both `defer`)
- Add `FormatUtils: 'readonly'` to ESLint browser globals
- Add 16 unit tests covering all 4 functions

## Test plan
- [x] `npm run test:unit` — 45/45 pass (29 existing + 16 new)
- [x] `npm run lint` — 0 errors
- [x] `npx prettier --check` — clean
- [ ] Manual: open `index.html` in browser, verify cost display and file download naming still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)