### PR TITLE
refactor: extract capability utils (unit-tested)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,6 +28,7 @@ export default [
         RecordingMonitor: 'writable',
         FileExtractor: 'writable',
         FormatUtils: 'readonly',
+        CapabilityUtils: 'readonly',
         STTProviders: 'writable',
         PCMStreamProcessor: 'writable',
         AudioResampler: 'writable',

--- a/index.html
+++ b/index.html
@@ -2601,6 +2601,8 @@
   <script src="js/file-extractor.js" defer></script>
   <!-- フォーマットユーティリティ -->
   <script src="js/lib/format-utils.js" defer></script>
+  <!-- 能力判定ユーティリティ -->
+  <script src="js/lib/capability-utils.js" defer></script>
   <!-- メインアプリ -->
   <script src="js/app.js" defer></script>
 </body>

--- a/js/app.js
+++ b/js/app.js
@@ -151,6 +151,10 @@ var formatNumber = FormatUtils.formatNumber;
 var sanitizeFileName = FormatUtils.sanitizeFileName;
 var deepCopy = FormatUtils.deepCopy;
 
+// --- Capability utilities (delegated to js/lib/capability-utils.js) ---
+var getCapabilities = CapabilityUtils.getCapabilities;
+var isReasoningCapableModel = CapabilityUtils.isReasoningCapableModel;
+
 // Sanitize error logs to remove potential API key leaks
 function sanitizeErrorLog(str) {
   if (typeof str !== 'string') return String(str);
@@ -6115,36 +6119,6 @@ function truncateText(text, limit = 160) {
 // =====================================
 // プロバイダ能力判定（Issue #14 two-toggles）
 // =====================================
-
-/**
- * プロバイダとモデルの能力を判定する
- * @param {string} provider - プロバイダ名 (anthropic, gemini, openai, groq)
- * @param {string} model - モデル名
- * @returns {{supportsReasoningControl: boolean, supportsNativeDocs: boolean, supportsVisionImages: boolean}}
- */
-function getCapabilities(provider, model) {
-  return {
-    supportsReasoningControl: provider === 'anthropic' && isReasoningCapableModel(model),
-    supportsNativeDocs: provider === 'gemini',
-    supportsVisionImages: false  // 将来拡張用
-  };
-}
-
-/**
- * Anthropicのthinking系パラメータを受け付けるモデルか判定
- * @param {string} model - モデル名
- * @returns {boolean}
- */
-function isReasoningCapableModel(model) {
-  if (!model) return false;
-  // Extended thinking対応モデル
-  const reasoningModels = [
-    'claude-sonnet-4',
-    'claude-opus-4',
-    'claude-3-7-sonnet'  // claude-3.7-sonnet系も対応
-  ];
-  return reasoningModels.some(m => model.includes(m));
-}
 
 /**
  * 現在のLLM設定から能力を取得

--- a/js/lib/capability-utils.js
+++ b/js/lib/capability-utils.js
@@ -1,0 +1,42 @@
+// Pure capability helpers — no DOM / i18n / global-state dependencies.
+// Consumed by app.js via thin aliases (e.g. var getCapabilities = CapabilityUtils.getCapabilities).
+const CapabilityUtils = (function () {
+  'use strict';
+
+  /**
+   * プロバイダとモデルの能力を判定する
+   * @param {string} provider - プロバイダ名 (anthropic, gemini, openai, groq)
+   * @param {string} model - モデル名
+   * @returns {{supportsReasoningControl: boolean, supportsNativeDocs: boolean, supportsVisionImages: boolean}}
+   */
+  function getCapabilities(provider, model) {
+    return {
+      supportsReasoningControl:
+        provider === 'anthropic' && isReasoningCapableModel(model),
+      supportsNativeDocs: provider === 'gemini',
+      supportsVisionImages: false // 将来拡張用
+    };
+  }
+
+  /**
+   * Anthropicのthinking系パラメータを受け付けるモデルか判定
+   * @param {string} model - モデル名
+   * @returns {boolean}
+   */
+  function isReasoningCapableModel(model) {
+    if (!model) return false;
+    // Extended thinking対応モデル
+    const reasoningModels = [
+      'claude-sonnet-4',
+      'claude-opus-4',
+      'claude-3-7-sonnet' // claude-3.7-sonnet系も対応
+    ];
+    return reasoningModels.some((m) => model.includes(m));
+  }
+
+  return { getCapabilities, isReasoningCapableModel };
+})();
+
+if (typeof window !== 'undefined') {
+  window.CapabilityUtils = CapabilityUtils;
+}

--- a/tests/unit/capability-utils.test.mjs
+++ b/tests/unit/capability-utils.test.mjs
@@ -1,0 +1,98 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadScript } from '../helpers/load-script.mjs';
+
+const { CapabilityUtils } = loadScript('js/lib/capability-utils.js');
+
+// ========================================
+// getCapabilities()
+// ========================================
+
+describe('getCapabilities', () => {
+  it('returns an object with expected keys', () => {
+    const caps = CapabilityUtils.getCapabilities('anthropic', 'claude-sonnet-4');
+    assert.ok('supportsReasoningControl' in caps);
+    assert.ok('supportsNativeDocs' in caps);
+    assert.ok('supportsVisionImages' in caps);
+  });
+
+  it('enables reasoning control for anthropic + reasoning model', () => {
+    const caps = CapabilityUtils.getCapabilities(
+      'anthropic',
+      'claude-sonnet-4-20250514'
+    );
+    assert.equal(caps.supportsReasoningControl, true);
+  });
+
+  it('disables reasoning control for non-anthropic provider', () => {
+    const caps = CapabilityUtils.getCapabilities(
+      'openai',
+      'claude-sonnet-4-20250514'
+    );
+    assert.equal(caps.supportsReasoningControl, false);
+  });
+
+  it('disables reasoning control for anthropic + non-reasoning model', () => {
+    const caps = CapabilityUtils.getCapabilities(
+      'anthropic',
+      'claude-3-5-haiku-20241022'
+    );
+    assert.equal(caps.supportsReasoningControl, false);
+  });
+
+  it('enables native docs for gemini provider', () => {
+    const caps = CapabilityUtils.getCapabilities(
+      'gemini',
+      'gemini-2.0-flash'
+    );
+    assert.equal(caps.supportsNativeDocs, true);
+  });
+
+  it('disables native docs for non-gemini provider', () => {
+    const caps = CapabilityUtils.getCapabilities('anthropic', 'claude-opus-4');
+    assert.equal(caps.supportsNativeDocs, false);
+  });
+});
+
+// ========================================
+// isReasoningCapableModel()
+// ========================================
+
+describe('isReasoningCapableModel', () => {
+  it('returns true for claude-sonnet-4 variant', () => {
+    assert.equal(
+      CapabilityUtils.isReasoningCapableModel('claude-sonnet-4-20250514'),
+      true
+    );
+  });
+
+  it('returns true for claude-opus-4 variant', () => {
+    assert.equal(
+      CapabilityUtils.isReasoningCapableModel('claude-opus-4-20250514'),
+      true
+    );
+  });
+
+  it('returns true for claude-3-7-sonnet variant', () => {
+    assert.equal(
+      CapabilityUtils.isReasoningCapableModel('claude-3-7-sonnet-20250219'),
+      true
+    );
+  });
+
+  it('returns false for non-reasoning model', () => {
+    assert.equal(
+      CapabilityUtils.isReasoningCapableModel('claude-3-5-haiku-20241022'),
+      false
+    );
+  });
+
+  it('returns false for null/undefined input', () => {
+    assert.equal(CapabilityUtils.isReasoningCapableModel(null), false);
+    assert.equal(CapabilityUtils.isReasoningCapableModel(undefined), false);
+  });
+
+  it('returns false for empty string', () => {
+    assert.equal(CapabilityUtils.isReasoningCapableModel(''), false);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract `getCapabilities()` and `isReasoningCapableModel()` from app.js into `js/lib/capability-utils.js`
- Keep app.js call sites unchanged via `var` aliases (same pattern as PR #116 FormatUtils)
- Add 12 unit tests for capability helpers (`node:test`)

## Changes
| File | Action |
|------|--------|
| `js/lib/capability-utils.js` | **NEW** — IIFE module with 2 pure functions |
| `js/app.js` | Remove 2 function defs, add alias imports |
| `index.html` | Add `<script>` before app.js |
| `eslint.config.mjs` | Add `CapabilityUtils: 'readonly'` |
| `tests/unit/capability-utils.test.mjs` | **NEW** — 12 test cases |

## Test plan
- [x] `npm run test:unit` — 57 tests pass (45 existing + 12 new)
- [x] `npm run lint` — 0 errors
- [ ] Browser: verify reasoning toggle still works with Anthropic models

🤖 Generated with [Claude Code](https://claude.com/claude-code)