### PR TITLE
refactor: extract sanitize utils (unit-tested)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,6 +29,7 @@ export default [
         FileExtractor: 'writable',
         FormatUtils: 'readonly',
         CapabilityUtils: 'readonly',
+        SanitizeUtils: 'readonly',
         STTProviders: 'writable',
         PCMStreamProcessor: 'writable',
         AudioResampler: 'writable',

--- a/index.html
+++ b/index.html
@@ -2603,6 +2603,8 @@
   <script src="js/lib/format-utils.js" defer></script>
   <!-- 能力判定ユーティリティ -->
   <script src="js/lib/capability-utils.js" defer></script>
+  <!-- サニタイズユーティリティ -->
+  <script src="js/lib/sanitize-utils.js" defer></script>
   <!-- メインアプリ -->
   <script src="js/app.js" defer></script>
 </body>

--- a/js/app.js
+++ b/js/app.js
@@ -155,16 +155,9 @@ var deepCopy = FormatUtils.deepCopy;
 var getCapabilities = CapabilityUtils.getCapabilities;
 var isReasoningCapableModel = CapabilityUtils.isReasoningCapableModel;
 
-// Sanitize error logs to remove potential API key leaks
-function sanitizeErrorLog(str) {
-  if (typeof str !== 'string') return String(str);
-  // Common API key patterns: sk-..., AIza..., dg_..., etc.
-  return str
-    .replace(/sk-[a-zA-Z0-9_-]{20,}/g, 'sk-***REDACTED***')
-    .replace(/AIza[a-zA-Z0-9_-]{30,}/g, 'AIza***REDACTED***')
-    .replace(/dg_[a-zA-Z0-9_-]{20,}/g, 'dg_***REDACTED***')
-    .replace(/[a-f0-9]{32,}/gi, '***HASH_REDACTED***');
-}
+// --- Sanitize utilities (delegated to js/lib/sanitize-utils.js) ---
+var sanitizeErrorLog = SanitizeUtils.sanitizeErrorLog;
+var truncateText = SanitizeUtils.truncateText;
 
 // Handle fatal errors - show modal and safely stop recording
 function handleFatalError(error) {
@@ -6107,13 +6100,6 @@ function formatHistoryDuration(seconds) {
   if (!seconds || Number.isNaN(seconds)) return '0m';
   const mins = Math.max(1, Math.round(seconds / 60));
   return `${mins}m`;
-}
-
-function truncateText(text, limit = 160) {
-  if (!text) return '';
-  const trimmed = text.trim();
-  if (trimmed.length <= limit) return trimmed;
-  return `${trimmed.slice(0, limit)}…`;
 }
 
 // =====================================

--- a/js/lib/sanitize-utils.js
+++ b/js/lib/sanitize-utils.js
@@ -1,0 +1,39 @@
+// Pure sanitizing/string helpers — no DOM / i18n / global-state dependencies.
+// Consumed by app.js via thin aliases (e.g. var sanitizeErrorLog = SanitizeUtils.sanitizeErrorLog).
+const SanitizeUtils = (function () {
+  'use strict';
+
+  /**
+   * Sanitize error logs to remove potential API key leaks
+   * @param {*} str - input (coerced to string if not already)
+   * @returns {string}
+   */
+  function sanitizeErrorLog(str) {
+    if (typeof str !== 'string') return String(str);
+    // Common API key patterns: sk-..., AIza..., dg_..., etc.
+    return str
+      .replace(/sk-[a-zA-Z0-9_-]{20,}/g, 'sk-***REDACTED***')
+      .replace(/AIza[a-zA-Z0-9_-]{30,}/g, 'AIza***REDACTED***')
+      .replace(/dg_[a-zA-Z0-9_-]{20,}/g, 'dg_***REDACTED***')
+      .replace(/[a-f0-9]{32,}/gi, '***HASH_REDACTED***');
+  }
+
+  /**
+   * Truncate text with ellipsis
+   * @param {string} text - input text
+   * @param {number} [limit=160] - max character count
+   * @returns {string}
+   */
+  function truncateText(text, limit = 160) {
+    if (!text) return '';
+    const trimmed = text.trim();
+    if (trimmed.length <= limit) return trimmed;
+    return `${trimmed.slice(0, limit)}\u2026`;
+  }
+
+  return { sanitizeErrorLog, truncateText };
+})();
+
+if (typeof window !== 'undefined') {
+  window.SanitizeUtils = SanitizeUtils;
+}

--- a/tests/unit/sanitize-utils.test.mjs
+++ b/tests/unit/sanitize-utils.test.mjs
@@ -1,0 +1,96 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadScript } from '../helpers/load-script.mjs';
+
+const { SanitizeUtils } = loadScript('js/lib/sanitize-utils.js');
+
+// Dynamic fake-key generators — avoid literal key strings that trigger secret scanning
+const fakeSk = () => 'sk' + '-' + 'a'.repeat(32);
+const fakeAIza = () => 'AI' + 'za' + 'Sy' + 'B'.repeat(32);
+const fakeDg = () => 'dg' + '_' + 'd'.repeat(32);
+const fakeHash = () => 'ab'.repeat(20);
+
+// ========================================
+// sanitizeErrorLog()
+// ========================================
+
+describe('sanitizeErrorLog', () => {
+  it('returns the string unchanged when no keys present', () => {
+    assert.equal(
+      SanitizeUtils.sanitizeErrorLog('just a normal error'),
+      'just a normal error'
+    );
+  });
+
+  it('redacts OpenAI-style sk- API keys', () => {
+    const input = 'Error with key ' + fakeSk();
+    const result = SanitizeUtils.sanitizeErrorLog(input);
+    assert.doesNotMatch(result, /sk-[a-zA-Z0-9_-]{20,}/);
+    assert.ok(result.includes('REDACTED'));
+  });
+
+  it('redacts Google AIza API keys', () => {
+    const input = 'key=' + fakeAIza();
+    const result = SanitizeUtils.sanitizeErrorLog(input);
+    assert.doesNotMatch(result, /AIza[a-zA-Z0-9_-]{30,}/);
+    assert.ok(result.includes('REDACTED'));
+  });
+
+  it('redacts Deepgram dg_ API keys', () => {
+    const input = 'token: ' + fakeDg();
+    const result = SanitizeUtils.sanitizeErrorLog(input);
+    assert.doesNotMatch(result, /dg_[a-zA-Z0-9_-]{20,}/);
+    assert.ok(result.includes('REDACTED'));
+  });
+
+  it('redacts long hex hashes', () => {
+    const input = 'hash: ' + fakeHash();
+    const result = SanitizeUtils.sanitizeErrorLog(input);
+    assert.doesNotMatch(result, /[a-f0-9]{32,}/i);
+    assert.ok(result.includes('HASH_REDACTED'));
+  });
+
+  it('coerces non-string input to string', () => {
+    assert.equal(SanitizeUtils.sanitizeErrorLog(42), '42');
+    assert.equal(SanitizeUtils.sanitizeErrorLog(null), 'null');
+    assert.equal(SanitizeUtils.sanitizeErrorLog(undefined), 'undefined');
+  });
+});
+
+// ========================================
+// truncateText()
+// ========================================
+
+describe('truncateText', () => {
+  it('returns short text unchanged', () => {
+    assert.equal(SanitizeUtils.truncateText('abc', 5), 'abc');
+  });
+
+  it('truncates text exceeding limit with ellipsis', () => {
+    const result = SanitizeUtils.truncateText('abcdef', 5);
+    assert.equal(result.length, 6); // 5 chars + ellipsis
+    assert.ok(result.endsWith('\u2026'));
+    assert.equal(result, 'abcde\u2026');
+  });
+
+  it('returns text at exact limit unchanged', () => {
+    assert.equal(SanitizeUtils.truncateText('abcde', 5), 'abcde');
+  });
+
+  it('trims whitespace before measuring', () => {
+    assert.equal(SanitizeUtils.truncateText('  abc  ', 5), 'abc');
+  });
+
+  it('returns empty string for null/undefined/empty input', () => {
+    assert.equal(SanitizeUtils.truncateText(null), '');
+    assert.equal(SanitizeUtils.truncateText(undefined), '');
+    assert.equal(SanitizeUtils.truncateText(''), '');
+  });
+
+  it('uses default limit of 160', () => {
+    const long = 'a'.repeat(200);
+    const result = SanitizeUtils.truncateText(long);
+    assert.equal(result.length, 161); // 160 + ellipsis
+    assert.ok(result.endsWith('\u2026'));
+  });
+});


### PR DESCRIPTION
## Summary
- Extract `sanitizeErrorLog()` and `truncateText()` from app.js into `js/lib/sanitize-utils.js`
- Keep app.js call sites unchanged via `var` aliases (same pattern as #116, #117)
- Add 12 unit tests for sanitize helpers (`node:test`)

## Changes
| File | Action |
|------|--------|
| `js/lib/sanitize-utils.js` | **NEW** — IIFE module with 2 pure functions |
| `js/app.js` | Remove 2 function defs, add alias imports |
| `index.html` | Add `<script>` before app.js |
| `eslint.config.mjs` | Add `SanitizeUtils: 'readonly'` |
| `tests/unit/sanitize-utils.test.mjs` | **NEW** — 12 test cases |

## Test plan
- [x] `npm run test:unit` — 69 tests pass (57 existing + 12 new)
- [x] `npm run lint` — 0 errors
- [ ] Browser: verify error logging still redacts API keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)