### PR TITLE
refactor: extract model utils (unit-tested)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,6 +30,7 @@ export default [
         FormatUtils: 'readonly',
         CapabilityUtils: 'readonly',
         SanitizeUtils: 'readonly',
+        ModelUtils: 'readonly',
         STTProviders: 'writable',
         PCMStreamProcessor: 'writable',
         AudioResampler: 'writable',

--- a/index.html
+++ b/index.html
@@ -2605,6 +2605,8 @@
   <script src="js/lib/capability-utils.js" defer></script>
   <!-- サニタイズユーティリティ -->
   <script src="js/lib/sanitize-utils.js" defer></script>
+  <!-- モデルユーティリティ -->
+  <script src="js/lib/model-utils.js" defer></script>
   <!-- メインアプリ -->
   <script src="js/app.js" defer></script>
 </body>

--- a/js/lib/model-utils.js
+++ b/js/lib/model-utils.js
@@ -1,0 +1,145 @@
+// Pure model-related helpers — no DOM / i18n / global-state dependencies.
+// Consumed by app.js via thin aliases (e.g. var getDefaultModel = ModelUtils.getDefaultModel).
+const ModelUtils = (function () {
+  'use strict';
+
+  /**
+   * STTプロバイダの表示名を返す
+   * @param {string} provider - プロバイダID
+   * @returns {string}
+   */
+  function getProviderDisplayName(provider) {
+    var names = {
+      openai_stt: 'OpenAI Whisper',
+      deepgram_realtime: 'Deepgram Realtime'
+    };
+    return names[provider] || provider;
+  }
+
+  /**
+   * Geminiモデル名から "models/" プレフィックスを除去
+   * @param {string} model - モデル名
+   * @returns {string}
+   */
+  function normalizeGeminiModelId(model) {
+    if (!model) return model;
+    if (model.startsWith('models/')) {
+      return model.slice(7); // "models/".length === 7
+    }
+    return model;
+  }
+
+  /**
+   * プロバイダのデフォルトモデルを返す
+   * @param {string} provider - プロバイダ名
+   * @returns {string|undefined}
+   */
+  function getDefaultModel(provider) {
+    var defaults = {
+      gemini: 'gemini-2.5-flash',
+      claude: 'claude-sonnet-4-20250514',
+      openai: 'gpt-4o',
+      openai_llm: 'gpt-4o',
+      groq: 'llama-3.3-70b-versatile'
+    };
+    return defaults[provider];
+  }
+
+  /**
+   * モデル未検出・非対応・廃止エラーかどうかを判定
+   * @param {{message?: string, status?: number}} error
+   * @returns {boolean}
+   */
+  function isModelNotFoundOrDeprecatedError(error) {
+    var msg = (error.message || '').toLowerCase();
+    return (
+      msg.includes('not found') ||
+      msg.includes('not supported') ||
+      msg.includes('does not exist') ||
+      msg.includes('model not available') ||
+      msg.includes('invalid model') ||
+      msg.includes('decommissioned') ||
+      msg.includes('no longer supported') ||
+      msg.includes('deprecated') ||
+      error.status === 404
+    );
+  }
+
+  /**
+   * モデル廃止エラーかどうかを判定
+   * @param {{message?: string}} error
+   * @returns {boolean}
+   */
+  function isModelDeprecatedError(error) {
+    var msg = (error.message || '').toLowerCase();
+    return (
+      msg.includes('decommissioned') ||
+      msg.includes('no longer supported') ||
+      msg.includes('deprecated') ||
+      msg.includes('model not found') ||
+      msg.includes('does not exist')
+    );
+  }
+
+  /**
+   * レート制限またはサーバーエラーかどうかを判定
+   * @param {{status?: number}} error
+   * @returns {boolean}
+   */
+  function isRateLimitOrServerError(error) {
+    return error.status === 429 || (error.status >= 500 && error.status < 600);
+  }
+
+  // プロバイダーごとの代替モデルリスト（優先順）
+  var ALTERNATIVE_MODELS = {
+    groq: ['llama-3.3-70b-versatile', 'llama-3.1-8b-instant']
+  };
+
+  /**
+   * 代替モデルリストを取得（現在のモデルを除外）
+   * @param {string} provider - プロバイダ名
+   * @param {string} currentModel - 現在のモデル名
+   * @returns {string[]}
+   */
+  function getAlternativeModels(provider, currentModel) {
+    var alts = ALTERNATIVE_MODELS[provider] || [];
+    return alts.filter(function (m) {
+      return m !== currentModel;
+    });
+  }
+
+  /**
+   * フォールバック用モデルを取得（リクエストモデルと同じなら null を返す）
+   * @param {string} provider - プロバイダ名
+   * @param {string} requestedModel - リクエストしたモデル名
+   * @returns {string|null}
+   */
+  function getFallbackModel(provider, requestedModel) {
+    var fallbacks = {
+      gemini: 'gemini-2.5-flash',
+      claude: 'claude-sonnet-4-20250514',
+      openai: 'gpt-4o',
+      openai_llm: 'gpt-4o',
+      groq: 'llama-3.3-70b-versatile'
+    };
+    var fb = fallbacks[provider];
+    // フォールバックが同じモデルなら再試行しない
+    if (!fb || fb === requestedModel) return null;
+    return fb;
+  }
+
+  return {
+    getProviderDisplayName,
+    normalizeGeminiModelId,
+    getDefaultModel,
+    isModelNotFoundOrDeprecatedError,
+    isModelDeprecatedError,
+    isRateLimitOrServerError,
+    getAlternativeModels,
+    getFallbackModel
+  };
+})();
+
+if (typeof window !== 'undefined') {
+  window.ModelUtils = ModelUtils;
+}

--- a/tests/unit/model-utils.test.mjs
+++ b/tests/unit/model-utils.test.mjs
@@ -1,0 +1,194 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadScript } from '../helpers/load-script.mjs';
+
+const { ModelUtils } = loadScript('js/lib/model-utils.js');
+
+// ========================================
+// getProviderDisplayName()
+// ========================================
+
+describe('getProviderDisplayName', () => {
+  it('returns display name for known STT providers', () => {
+    assert.equal(
+      ModelUtils.getProviderDisplayName('openai_stt'),
+      'OpenAI Whisper'
+    );
+    assert.equal(
+      ModelUtils.getProviderDisplayName('deepgram_realtime'),
+      'Deepgram Realtime'
+    );
+  });
+
+  it('returns the raw provider string for unknown providers', () => {
+    assert.equal(ModelUtils.getProviderDisplayName('custom'), 'custom');
+  });
+});
+
+// ========================================
+// normalizeGeminiModelId()
+// ========================================
+
+describe('normalizeGeminiModelId', () => {
+  it('strips models/ prefix', () => {
+    assert.equal(
+      ModelUtils.normalizeGeminiModelId('models/gemini-2.0-flash'),
+      'gemini-2.0-flash'
+    );
+  });
+
+  it('returns model without prefix unchanged', () => {
+    assert.equal(
+      ModelUtils.normalizeGeminiModelId('gemini-2.0-flash'),
+      'gemini-2.0-flash'
+    );
+  });
+
+  it('returns falsy input unchanged', () => {
+    assert.equal(ModelUtils.normalizeGeminiModelId(null), null);
+    assert.equal(ModelUtils.normalizeGeminiModelId(''), '');
+  });
+});
+
+// ========================================
+// getDefaultModel()
+// ========================================
+
+describe('getDefaultModel', () => {
+  it('returns a default model for each known provider', () => {
+    for (const p of ['gemini', 'claude', 'openai', 'openai_llm', 'groq']) {
+      const result = ModelUtils.getDefaultModel(p);
+      assert.equal(typeof result, 'string');
+      assert.ok(result.length > 0);
+    }
+  });
+
+  it('returns undefined for unknown provider', () => {
+    assert.equal(ModelUtils.getDefaultModel('unknown'), undefined);
+  });
+});
+
+// ========================================
+// isModelNotFoundOrDeprecatedError()
+// ========================================
+
+describe('isModelNotFoundOrDeprecatedError', () => {
+  it('returns true for "not found" message', () => {
+    assert.equal(
+      ModelUtils.isModelNotFoundOrDeprecatedError({ message: 'Model not found' }),
+      true
+    );
+  });
+
+  it('returns true for status 404', () => {
+    assert.equal(
+      ModelUtils.isModelNotFoundOrDeprecatedError({ message: '', status: 404 }),
+      true
+    );
+  });
+
+  it('returns true for "deprecated" message', () => {
+    assert.equal(
+      ModelUtils.isModelNotFoundOrDeprecatedError({
+        message: 'This model is deprecated'
+      }),
+      true
+    );
+  });
+
+  it('returns false for generic error', () => {
+    assert.equal(
+      ModelUtils.isModelNotFoundOrDeprecatedError({
+        message: 'Internal server error',
+        status: 500
+      }),
+      false
+    );
+  });
+});
+
+// ========================================
+// isModelDeprecatedError()
+// ========================================
+
+describe('isModelDeprecatedError', () => {
+  it('returns true for decommissioned message', () => {
+    assert.equal(
+      ModelUtils.isModelDeprecatedError({ message: 'Model decommissioned' }),
+      true
+    );
+  });
+
+  it('returns false for rate limit error', () => {
+    assert.equal(
+      ModelUtils.isModelDeprecatedError({ message: 'Rate limit exceeded' }),
+      false
+    );
+  });
+});
+
+// ========================================
+// isRateLimitOrServerError()
+// ========================================
+
+describe('isRateLimitOrServerError', () => {
+  it('returns true for status 429', () => {
+    assert.equal(
+      ModelUtils.isRateLimitOrServerError({ status: 429 }),
+      true
+    );
+  });
+
+  it('returns true for 5xx status', () => {
+    assert.equal(ModelUtils.isRateLimitOrServerError({ status: 500 }), true);
+    assert.equal(ModelUtils.isRateLimitOrServerError({ status: 503 }), true);
+  });
+
+  it('returns false for 4xx (non-429)', () => {
+    assert.equal(ModelUtils.isRateLimitOrServerError({ status: 400 }), false);
+    assert.equal(ModelUtils.isRateLimitOrServerError({ status: 404 }), false);
+  });
+});
+
+// ========================================
+// getAlternativeModels()
+// ========================================
+
+describe('getAlternativeModels', () => {
+  it('returns alternatives excluding current model for groq', () => {
+    const alts = ModelUtils.getAlternativeModels(
+      'groq',
+      'llama-3.3-70b-versatile'
+    );
+    assert.ok(Array.isArray(alts));
+    assert.ok(alts.length > 0);
+    assert.ok(!alts.includes('llama-3.3-70b-versatile'));
+  });
+
+  it('returns empty array for provider with no alternatives', () => {
+    const alts = ModelUtils.getAlternativeModels('openai', 'gpt-4o');
+    assert.ok(Array.isArray(alts));
+    assert.equal(alts.length, 0);
+  });
+});
+
+// ========================================
+// getFallbackModel()
+// ========================================
+
+describe('getFallbackModel', () => {
+  it('returns fallback model different from requested', () => {
+    const fb = ModelUtils.getFallbackModel('groq', 'some-old-model');
+    assert.equal(typeof fb, 'string');
+    assert.notEqual(fb, 'some-old-model');
+  });
+
+  it('returns null when fallback equals requested model', () => {
+    const defaultModel = ModelUtils.getDefaultModel('gemini');
+    assert.equal(ModelUtils.getFallbackModel('gemini', defaultModel), null);
+  });
+
+  it('returns null for unknown provider', () => {
+    assert.equal(ModelUtils.getFallbackModel('unknown', 'foo'), null);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract 8 pure model helpers from app.js into `js/lib/model-utils.js`
- Functions: `getProviderDisplayName`, `normalizeGeminiModelId`, `getDefaultModel`, `isModelNotFoundOrDeprecatedError`, `isModelDeprecatedError`, `isRateLimitOrServerError`, `getAlternativeModels`, `getFallbackModel`
- Also moves `ALTERNATIVE_MODELS` constant into the module
- Keep app.js call sites unchanged via `var` aliases (same pattern as #116, #117, #118)
- Add 21 unit tests for model helpers (`node:test`)

## Changes
| File | Action |
|------|--------|
| `js/lib/model-utils.js` | **NEW** — IIFE module with 8 pure functions |
| `js/app.js` | Remove 8 function defs + 1 const, add alias imports (-86 lines) |
| `index.html` | Add `<script>` before app.js |
| `eslint.config.mjs` | Add `ModelUtils: 'readonly'` |
| `tests/unit/model-utils.test.mjs` | **NEW** — 21 test cases |

## Test plan
- [x] `npm run test:unit` — 90 tests pass (69 existing + 21 new)
- [x] `npm run lint` — 0 errors
- [ ] Browser: verify LLM calls with fallback/alternative model logic still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)