### PR TITLE
refactor: extract text utils (unit-tested)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,6 +31,7 @@ export default [
         CapabilityUtils: 'readonly',
         SanitizeUtils: 'readonly',
         ModelUtils: 'readonly',
+        TextUtils: 'readonly',
         STTProviders: 'writable',
         PCMStreamProcessor: 'writable',
         AudioResampler: 'writable',

--- a/index.html
+++ b/index.html
@@ -2607,6 +2607,8 @@
   <script src="js/lib/sanitize-utils.js" defer></script>
   <!-- モデルユーティリティ -->
   <script src="js/lib/model-utils.js" defer></script>
+  <!-- テキストユーティリティ -->
+  <script src="js/lib/text-utils.js" defer></script>
   <!-- メインアプリ -->
   <script src="js/app.js" defer></script>
 </body>

--- a/js/lib/text-utils.js
+++ b/js/lib/text-utils.js
@@ -1,0 +1,71 @@
+// Pure text-parsing helpers — no DOM / i18n / global-state dependencies.
+// Consumed by app.js via thin aliases (e.g. var fixBrokenNumbers = TextUtils.fixBrokenNumbers).
+const TextUtils = (function () {
+  'use strict';
+
+  /**
+   * 単桁がカンマで連なる崩れた数値を結合する
+   * パターン: 数字1桁 + (カンマ + 数字1桁) が3回以上繰り返し
+   * → 4桁以上の崩れた数値のみ対象（1,2,3のような短い列挙は除外）
+   * @param {string} text - テキスト
+   * @returns {string}
+   */
+  function fixBrokenNumbers(text) {
+    return text.replace(/\b(\d)(,\d){3,}\b/g, function (match) {
+      return match.replace(/,/g, '');
+    });
+  }
+
+  /**
+   * "HH:MM" 形式のタイムスタンプをミリ秒に変換する
+   * @param {string} timestamp - "HH:MM" 形式の文字列
+   * @returns {number} ミリ秒（パース失敗時は 0）
+   */
+  function parseTimestampToMs(timestamp) {
+    if (!timestamp) return 0;
+    var parts = timestamp.split(':').map(Number);
+    if (parts.length === 2) {
+      var h = parts[0];
+      var m = parts[1];
+      return (h * 60 + m) * 60 * 1000;
+    }
+    return 0;
+  }
+
+  /**
+   * メモ行からAI指示を抽出する
+   * 対応パターン: 【AI】xxx, AI: xxx, @ai xxx
+   * @param {string} line - メモの1行
+   * @returns {string|null} 抽出された指示テキスト、またはnull
+   */
+  function extractAiInstructionFromMemoLine(line) {
+    if (!line || typeof line !== 'string') return null;
+    var text = line.trim();
+    if (!text) return null;
+
+    var patterns = [
+      /^\s*(?:[-*•]\s*)?【\s*AI\s*】\s*(.+)$/i,
+      /^\s*(?:[-*•]\s*)?AI\s*[:：]\s*(.+)$/i,
+      /^\s*(?:[-*•]\s*)?[@＠]ai\b[\s:：-]*(.+)$/i
+    ];
+
+    for (var i = 0; i < patterns.length; i += 1) {
+      var match = text.match(patterns[i]);
+      if (match && match[1]) {
+        var instruction = match[1].trim();
+        if (instruction) return instruction;
+      }
+    }
+    return null;
+  }
+
+  return {
+    fixBrokenNumbers: fixBrokenNumbers,
+    parseTimestampToMs: parseTimestampToMs,
+    extractAiInstructionFromMemoLine: extractAiInstructionFromMemoLine
+  };
+})();
+
+if (typeof window !== 'undefined') {
+  window.TextUtils = TextUtils;
+}

--- a/tests/unit/text-utils.test.mjs
+++ b/tests/unit/text-utils.test.mjs
@@ -1,0 +1,140 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadScript } from '../helpers/load-script.mjs';
+
+const { TextUtils } = loadScript('js/lib/text-utils.js');
+
+// ========================================
+// fixBrokenNumbers()
+// ========================================
+
+describe('fixBrokenNumbers', () => {
+  it('joins single-digit comma sequences (4+ digits)', () => {
+    assert.equal(TextUtils.fixBrokenNumbers('1,2,3,4'), '1234');
+  });
+
+  it('joins longer sequences', () => {
+    assert.equal(TextUtils.fixBrokenNumbers('1,0,0,0,0'), '10000');
+  });
+
+  it('leaves 3-digit comma sequences unchanged (too short)', () => {
+    assert.equal(TextUtils.fixBrokenNumbers('1,2,3'), '1,2,3');
+  });
+
+  it('leaves normal comma-separated numbers unchanged', () => {
+    assert.equal(TextUtils.fixBrokenNumbers('1,000'), '1,000');
+  });
+
+  it('handles text with embedded broken numbers', () => {
+    const result = TextUtils.fixBrokenNumbers('合計は1,2,3,4円です');
+    assert.equal(result, '合計は1234円です');
+  });
+
+  it('handles text with no numbers', () => {
+    assert.equal(TextUtils.fixBrokenNumbers('hello world'), 'hello world');
+  });
+});
+
+// ========================================
+// parseTimestampToMs()
+// ========================================
+
+describe('parseTimestampToMs', () => {
+  it('parses HH:MM to milliseconds', () => {
+    // 1:00 = 60 minutes = 3600 seconds = 3,600,000 ms
+    assert.equal(TextUtils.parseTimestampToMs('1:00'), 3600000);
+  });
+
+  it('parses 0:30 to 30 minutes in ms', () => {
+    // 0:30 = 30 minutes = 1800 seconds = 1,800,000 ms
+    assert.equal(TextUtils.parseTimestampToMs('0:30'), 1800000);
+  });
+
+  it('parses 2:15 correctly', () => {
+    // 2h15m = 135 minutes = 8100 seconds = 8,100,000 ms
+    assert.equal(TextUtils.parseTimestampToMs('2:15'), 8100000);
+  });
+
+  it('returns 0 for falsy input', () => {
+    assert.equal(TextUtils.parseTimestampToMs(null), 0);
+    assert.equal(TextUtils.parseTimestampToMs(''), 0);
+    assert.equal(TextUtils.parseTimestampToMs(undefined), 0);
+  });
+
+  it('returns 0 for non-HH:MM format', () => {
+    assert.equal(TextUtils.parseTimestampToMs('abc'), 0);
+    assert.equal(TextUtils.parseTimestampToMs('1:2:3'), 0);
+  });
+});
+
+// ========================================
+// extractAiInstructionFromMemoLine()
+// ========================================
+
+describe('extractAiInstructionFromMemoLine', () => {
+  it('extracts instruction from 【AI】 pattern', () => {
+    assert.equal(
+      TextUtils.extractAiInstructionFromMemoLine('【AI】要約してください'),
+      '要約してください'
+    );
+  });
+
+  it('extracts instruction from 【 AI 】 with spaces', () => {
+    assert.equal(
+      TextUtils.extractAiInstructionFromMemoLine('【 AI 】 詳細を説明して'),
+      '詳細を説明して'
+    );
+  });
+
+  it('extracts instruction from AI: pattern', () => {
+    assert.equal(
+      TextUtils.extractAiInstructionFromMemoLine('AI: summarize this'),
+      'summarize this'
+    );
+  });
+
+  it('extracts instruction from AI： (fullwidth colon)', () => {
+    assert.equal(
+      TextUtils.extractAiInstructionFromMemoLine('AI：翻訳して'),
+      '翻訳して'
+    );
+  });
+
+  it('extracts instruction from @ai pattern', () => {
+    assert.equal(
+      TextUtils.extractAiInstructionFromMemoLine('@ai explain this'),
+      'explain this'
+    );
+  });
+
+  it('extracts instruction from ＠ai pattern (fullwidth @)', () => {
+    assert.equal(
+      TextUtils.extractAiInstructionFromMemoLine('＠ai まとめて'),
+      'まとめて'
+    );
+  });
+
+  it('extracts instruction from bullet-prefixed line', () => {
+    assert.equal(
+      TextUtils.extractAiInstructionFromMemoLine('- 【AI】分析してください'),
+      '分析してください'
+    );
+  });
+
+  it('returns null for non-matching line', () => {
+    assert.equal(
+      TextUtils.extractAiInstructionFromMemoLine('普通のメモ行です'),
+      null
+    );
+  });
+
+  it('returns null for null/undefined/empty', () => {
+    assert.equal(TextUtils.extractAiInstructionFromMemoLine(null), null);
+    assert.equal(TextUtils.extractAiInstructionFromMemoLine(undefined), null);
+    assert.equal(TextUtils.extractAiInstructionFromMemoLine(''), null);
+  });
+
+  it('returns null for whitespace-only input', () => {
+    assert.equal(TextUtils.extractAiInstructionFromMemoLine('   '), null);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract 3 pure text-parsing functions from `app.js` into `js/lib/text-utils.js` (IIFE module)
  - `fixBrokenNumbers` — joins single-digit comma sequences (e.g. `1,2,3,4` → `1234`)
  - `parseTimestampToMs` — converts `HH:MM` to milliseconds
  - `extractAiInstructionFromMemoLine` — extracts AI instructions from memo lines (【AI】, AI:, @ai patterns)
- app.js aliases preserve all existing call sites (zero refactoring of callers)
- 21 unit tests added (total: 111 passing)
- app.js net reduction: **-38 lines**

## Changes
| File | Action |
|------|--------|
| `js/lib/text-utils.js` | **CREATE** — IIFE module with 3 functions |
| `js/app.js` | MODIFY — alias refs + delete originals |
| `index.html` | MODIFY — add `<script defer>` before app.js |
| `eslint.config.mjs` | MODIFY — add `TextUtils: 'readonly'` |
| `tests/unit/text-utils.test.mjs` | **CREATE** — 21 test cases |

## Cumulative progress (PR2-2 → PR2-6)
| PR | Module | app.js reduction | Tests |
|----|--------|-----------------|-------|
| #116 | format-utils | -29 | 16 |
| #117 | capability-utils | -30 | 12 |
| #118 | sanitize-utils | -17 | 12 |
| #119 | model-utils | -86 | 21 |
| **this** | **text-utils** | **-38** | **21** |
| **Total** | | **-200 lines** | **82 tests** |

## Test plan
- [x] `npm run test:unit` — 111 tests pass (0 fail)
- [x] `npm run lint` — 0 errors
- [ ] CI: lint + e2e + Secret Scanning

🤖 Generated with [Claude Code](https://claude.com/claude-code)