### PR TITLE
feat(context): clarify PDF Native Docs API requirements

### DIFF
--- a/config.html
+++ b/config.html
@@ -981,7 +981,7 @@
           <label for="enhancedContext" data-i18n="config.options.enhancedContextEnabled">Enable file attachments for meeting context</label>
         </div>
         <div class="setting-hint" data-i18n="config.options.enhancedContextHint">
-          When enabled, you can attach TXT/MD files to provide additional meeting context to AI.
+          When enabled, you can attach TXT/MD/PDF/DOCX/CSV files to provide additional meeting context to AI.
         </div>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -2100,6 +2100,7 @@
             <div style="flex:1;">
               <span data-i18n="context.nativeDocsLabel">資料そのまま送信</span>
               <span class="toggle-hint" style="font-size:0.75rem; color:var(--text-secondary); display:block;" data-i18n="context.nativeDocsHint">PDFをそのまま送信・精度向上/コスト増の可能性</span>
+              <span class="toggle-hint" style="font-size:0.72rem; color:var(--text-secondary); display:block;" data-i18n="context.nativeDocsApiGuide">必要API: Gemini API（モデル例: gemini-2.5-flash / gemini-2.5-pro）</span>
               <span class="toggle-disabled-reason" id="nativeDocsDisabledReason" style="font-size:0.7rem; color:var(--warning); display:none;"></span>
             </div>
             <label class="switch">

--- a/locales/en.json
+++ b/locales/en.json
@@ -283,7 +283,7 @@
       "costAlertEnabled": "Show warning at 80% of limit",
       "enhancedContextTitle": "Enhanced Context",
       "enhancedContextEnabled": "Enable file attachments for meeting context",
-      "enhancedContextHint": "When enabled, you can attach TXT/MD files to provide additional meeting materials to AI."
+      "enhancedContextHint": "When enabled, you can attach TXT/MD/PDF/DOCX/CSV files to provide additional meeting materials to AI."
     },
     "theme": {
       "title": "Appearance",
@@ -601,7 +601,11 @@
     "reasoningBoostDisabled": "Not available for this provider/model",
     "nativeDocsLabel": "Native Docs",
     "nativeDocsHint": "Send PDFs directly - may improve accuracy/increase cost",
+    "nativeDocsApiGuide": "Required API: Gemini API (model examples: gemini-2.5-flash / gemini-2.5-pro / gemini-2.0-flash)",
     "nativeDocsDisabled": "Only available with Gemini + PDF attached",
+    "nativeDocsNeedsGeminiKey": "Gemini API key (LLM settings) is required",
+    "nativeDocsNeedsGeminiPriority": "Set LLM priority to Gemini (or keep auto so Gemini is selected)",
+    "nativeDocsNeedsPdf": "Attach at least one PDF file to enable this",
     "nativeDocsFallback": "Native Docs failed, falling back to text extraction",
     "badgeReasoningBoost": "Boost ON",
     "badgeNativeDocs": "Native Docs ON"

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -283,7 +283,7 @@
       "costAlertEnabled": "上限の80%で警告を表示",
       "enhancedContextTitle": "強化コンテキスト",
       "enhancedContextEnabled": "ファイル添付による会議資料の提供を有効化",
-      "enhancedContextHint": "有効にすると、TXT/MDファイルを添付してAIに追加の会議資料を提供できます。"
+      "enhancedContextHint": "有効にすると、TXT/MD/PDF/DOCX/CSVファイルを添付してAIに追加の会議資料を提供できます。"
     },
     "theme": {
       "title": "外観",
@@ -601,7 +601,11 @@
     "reasoningBoostDisabled": "このプロバイダ/モデルでは使用不可",
     "nativeDocsLabel": "資料そのまま送信",
     "nativeDocsHint": "PDFをそのまま送信・精度向上/コスト増の可能性",
+    "nativeDocsApiGuide": "必要API: Gemini API（モデル例: gemini-2.5-flash / gemini-2.5-pro / gemini-2.0-flash）",
     "nativeDocsDisabled": "GeminiプロバイダーでPDF添付がある場合のみ",
+    "nativeDocsNeedsGeminiKey": "Gemini APIキー（LLM設定）が必要です",
+    "nativeDocsNeedsGeminiPriority": "LLM優先順位をGeminiに設定（またはautoでGeminiが選ばれる状態）してください",
+    "nativeDocsNeedsPdf": "PDFファイルを添付すると有効になります",
     "nativeDocsFallback": "Native Docsに失敗、テキスト抽出にフォールバック",
     "badgeReasoningBoost": "Boost ON",
     "badgeNativeDocs": "Native Docs ON"

--- a/tests/unit/capability-utils.test.mjs
+++ b/tests/unit/capability-utils.test.mjs
@@ -55,6 +55,74 @@ describe('getCapabilities', () => {
 });
 
 // ========================================
+// normalizeCapabilityProvider()
+// ========================================
+
+describe('normalizeCapabilityProvider', () => {
+  it('maps claude to anthropic', () => {
+    assert.equal(CapabilityUtils.normalizeCapabilityProvider('claude'), 'anthropic');
+  });
+
+  it('maps openai_llm to openai', () => {
+    assert.equal(CapabilityUtils.normalizeCapabilityProvider('openai_llm'), 'openai');
+  });
+
+  it('keeps gemini unchanged', () => {
+    assert.equal(CapabilityUtils.normalizeCapabilityProvider('gemini'), 'gemini');
+  });
+
+  it('returns empty string for falsy input', () => {
+    assert.equal(CapabilityUtils.normalizeCapabilityProvider(''), '');
+    assert.equal(CapabilityUtils.normalizeCapabilityProvider(null), '');
+  });
+});
+
+// ========================================
+// resolveEffectiveLlmProvider()
+// ========================================
+
+describe('resolveEffectiveLlmProvider', () => {
+  it('returns priority provider when key exists', () => {
+    const hasApiKey = (provider) => provider === 'gemini';
+    assert.equal(
+      CapabilityUtils.resolveEffectiveLlmProvider('gemini', hasApiKey),
+      'gemini'
+    );
+  });
+
+  it('falls back to default order when priority has no key', () => {
+    const hasApiKey = (provider) => provider === 'openai_llm';
+    assert.equal(
+      CapabilityUtils.resolveEffectiveLlmProvider('gemini', hasApiKey),
+      'openai_llm'
+    );
+  });
+
+  it('uses auto order when priority is auto', () => {
+    const hasApiKey = (provider) => provider === 'groq';
+    assert.equal(
+      CapabilityUtils.resolveEffectiveLlmProvider('auto', hasApiKey),
+      'groq'
+    );
+  });
+
+  it('returns null when no provider has a key', () => {
+    const hasApiKey = () => false;
+    assert.equal(
+      CapabilityUtils.resolveEffectiveLlmProvider('auto', hasApiKey),
+      null
+    );
+  });
+
+  it('returns null when hasApiKey callback is missing', () => {
+    assert.equal(
+      CapabilityUtils.resolveEffectiveLlmProvider('auto'),
+      null
+    );
+  });
+});
+
+// ========================================
 // isReasoningCapableModel()
 // ========================================
 


### PR DESCRIPTION
## Summary
- fix Native Docs enable/disable logic to use the actual effective LLM provider and proper provider-id normalization
- add explicit in-UI guidance for required API key/model examples for PDF Native Docs (Gemini)
- improve disabled reason messaging (missing Gemini key / Gemini not selected / PDF not attached)
- expand enhanced-context copy to match actual supported file formats
- add unit tests for capability provider normalization and effective provider resolution

## Testing
- npm run test:i18n
- npm run test:unit
- npm run lint

Closes #122