### PR TITLE
fix: respect STT language for chunked Whisper

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1853,7 +1853,8 @@ async function startChunkedRecording(provider) {
   // OpenAI Whisperプロバイダーを作成
   AppState.currentSTTProvider = new OpenAIChunkedProvider({
     apiKey: SecureStorage.getApiKey('openai'),
-    model: SecureStorage.getModel('openai') || 'whisper-1'
+    model: SecureStorage.getModel('openai') || 'whisper-1',
+    language: SecureStorage.getOption('sttLanguage', 'ja')
   });
 
   AppState.currentSTTProvider.setOnTranscript((text, isFinal) => {

--- a/js/stt/providers/openai_chunked.js
+++ b/js/stt/providers/openai_chunked.js
@@ -13,7 +13,7 @@ class OpenAIChunkedProvider {
     this.config = config;
     this.apiKey = config.apiKey || SecureStorage.getApiKey('openai');
     this.model = config.model || SecureStorage.getModel('openai') || 'whisper-1';
-    this.language = config.language || 'ja';
+    this.language = config.language || SecureStorage.getOption('sttLanguage', 'ja') || 'ja';
     // ユーザー辞書（固有名詞のヒント）- 設定画面から登録可能
     // デフォルト辞書 + ユーザー辞書を結合
     this.userDictionary = this._loadUserDictionary(config.userDictionary);
@@ -81,7 +81,14 @@ class OpenAIChunkedProvider {
 
     // promptを構築（前チャンクの末尾 + ユーザー辞書）
     const promptParts = [];
-    const tailToUse = previousTail || this.lastTranscriptTail;
+    let tailToUse = previousTail || this.lastTranscriptTail;
+    if (this.language !== 'ja' && tailToUse) {
+      const hasJapanese = /[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF]/.test(tailToUse);
+      if (hasJapanese) {
+        tailToUse = '';
+        DebugLogger.log('[OpenAI STT]', 'Skipping last transcript tail for non-Japanese mode');
+      }
+    }
     if (tailToUse) {
       promptParts.push(tailToUse);
     }
@@ -104,7 +111,9 @@ class OpenAIChunkedProvider {
       const formData = new FormData();
       formData.append('file', audioBlob, 'audio.webm');
       formData.append('model', this.model);
-      formData.append('language', this.language);
+      if (this.language && this.language !== 'auto') {
+        formData.append('language', this.language);
+      }
 
       // promptパラメータを追加（空でない場合のみ）
       if (prompt) {

--- a/tests/unit/openai-chunked-provider.test.mjs
+++ b/tests/unit/openai-chunked-provider.test.mjs
@@ -1,0 +1,124 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadScript } from '../helpers/load-script.mjs';
+
+class FakeFormData {
+  constructor() {
+    this.entries = [];
+  }
+
+  append(name, value, filename) {
+    this.entries.push({ name, value, filename });
+  }
+
+  has(name) {
+    return this.entries.some((entry) => entry.name === name);
+  }
+
+  get(name) {
+    const entry = this.entries.find((item) => item.name === name);
+    return entry ? entry.value : null;
+  }
+}
+
+function createProviderContext({ storedLanguage = 'ja' } = {}) {
+  const requests = [];
+  const SecureStorage = {
+    getApiKey() {
+      return 'test-openai-key';
+    },
+    getModel() {
+      return 'whisper-1';
+    },
+    getOption(key, fallback = '') {
+      if (key === 'sttLanguage') return storedLanguage;
+      if (key === 'sttUserDictionary') return '';
+      return fallback;
+    }
+  };
+  const DebugLogger = {
+    log() {},
+    error() {}
+  };
+  const window = {};
+  loadScript('js/stt/providers/openai_chunked.js', {
+    window,
+    SecureStorage,
+    DebugLogger,
+    FormData: FakeFormData,
+    fetch: async (url, options) => {
+      requests.push({ url, options, formData: options.body });
+      return {
+        ok: true,
+        json: async () => ({ text: 'recognized text' })
+      };
+    }
+  });
+
+  return {
+    OpenAIChunkedProvider: window.OpenAIChunkedProvider,
+    requests
+  };
+}
+
+async function transcribeWithLanguage(language) {
+  const { OpenAIChunkedProvider, requests } = createProviderContext();
+  const provider = new OpenAIChunkedProvider({
+    apiKey: 'test-openai-key',
+    model: 'whisper-1',
+    language
+  });
+
+  await provider.start();
+  await provider.transcribeBlob(new Blob(['audio'], { type: 'audio/webm' }));
+
+  return requests[0].formData;
+}
+
+describe('OpenAIChunkedProvider language option', () => {
+  it('sends language=ja when configured for Japanese', async () => {
+    const formData = await transcribeWithLanguage('ja');
+
+    assert.equal(formData.get('language'), 'ja');
+  });
+
+  it('sends language=en when configured for English', async () => {
+    const formData = await transcribeWithLanguage('en');
+
+    assert.equal(formData.get('language'), 'en');
+  });
+
+  it('omits the language parameter when configured for auto detection', async () => {
+    const formData = await transcribeWithLanguage('auto');
+
+    assert.equal(formData.has('language'), false);
+  });
+
+  it('uses saved sttLanguage when no language is passed in config', async () => {
+    const { OpenAIChunkedProvider, requests } = createProviderContext({ storedLanguage: 'en' });
+    const provider = new OpenAIChunkedProvider({
+      apiKey: 'test-openai-key',
+      model: 'whisper-1'
+    });
+
+    await provider.start();
+    await provider.transcribeBlob(new Blob(['audio'], { type: 'audio/webm' }));
+
+    assert.equal(requests[0].formData.get('language'), 'en');
+  });
+
+  it('does not include Japanese previous tail in prompts for non-Japanese modes', async () => {
+    const { OpenAIChunkedProvider, requests } = createProviderContext();
+    const provider = new OpenAIChunkedProvider({
+      apiKey: 'test-openai-key',
+      model: 'whisper-1',
+      language: 'en',
+      userDictionary: 'project term'
+    });
+
+    await provider.start();
+    await provider.transcribeBlob(new Blob(['audio'], { type: 'audio/webm' }), '前回の日本語テキスト');
+
+    assert.equal(requests[0].formData.get('prompt'), 'project term');
+  });
+});


### PR DESCRIPTION
## Summary
- Pass saved `sttLanguage` from `startChunkedRecording` into `OpenAIChunkedProvider`
- Send `language=ja` when STT language is Japanese
- Send `language=en` when STT language is English
- Do not append any `language` field when STT language is `auto`
- Avoid mixing Japanese previous-tail prompt text into non-Japanese modes
- Add unit coverage for `ja`, `en`, `auto`, saved-language fallback, and non-Japanese prompt-tail handling

## Root cause
The normal chunked Whisper path constructed `OpenAIChunkedProvider` without the saved language option, and the provider defaulted to `ja` while always appending `language` to FormData. This made `en` and `auto` settings ineffective for the chunked path.

## Validation
- `npm run test:unit`: passed, 176 tests
- `npm run lint`: passed with existing 8 warnings
- `git diff --check`: passed

## Manual behavior covered by unit tests
- `ja` -> FormData includes `language=ja`
- `en` -> FormData includes `language=en`
- `auto` -> FormData does not include `language`
- Non-Japanese modes do not include Japanese previous-tail prompt text

## Notes for reviewers
- This PR is rebased onto main after PR #138, so the activeMeetingDraft changes are included in base main rather than this diff.