### PR TITLE
fix: surface transcription queue overflow

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -38,6 +38,7 @@ export default [
         ModelRegistryCacheStore: 'readonly',
         LLMClientService: 'readonly',
         MeetingContextService: 'readonly',
+        TranscriptionQueueOverflowService: 'readonly',
         ExportService: 'readonly',
         DiagnosticsService: 'readonly',
         STTProviders: 'writable',

--- a/index.html
+++ b/index.html
@@ -733,6 +733,7 @@
   <script src="js/services/llm-client.js" defer></script>
   <script src="js/services/meeting-context-service.js" defer></script>
   <script src="js/services/active-meeting-draft-service.js" defer></script>
+  <script src="js/services/transcription-queue-overflow-service.js" defer></script>
   <script src="js/services/export-service.js" defer></script>
   <script src="js/services/diagnostics-service.js" defer></script>
   <!-- メインアプリ -->

--- a/js/app.js
+++ b/js/app.js
@@ -153,6 +153,10 @@ let qaEventLog = [];
 // Issue #40: Global error handling
 let errorHandlerActive = false;
 
+const TRANSCRIPTION_QUEUE_MAX_LENGTH = 3;
+const TRANSCRIPTION_QUEUE_OVERFLOW_TOAST_COOLDOWN_MS = 15000;
+let transcriptionQueueOverflow = TranscriptionQueueOverflowService.createInitialState();
+
 // App-wide state aggregate (Issue #131)
 const AppState = {
   get isRecording() { return isRecording; },
@@ -263,6 +267,8 @@ const AppState = {
   set lastTranscriptTail(value) { lastTranscriptTail = value; },
   get queueDrainResolvers() { return queueDrainResolvers; },
   set queueDrainResolvers(value) { queueDrainResolvers = value; },
+  get transcriptionQueueOverflow() { return transcriptionQueueOverflow; },
+  set transcriptionQueueOverflow(value) { transcriptionQueueOverflow = value; },
   get whisperUserDictionary() { return whisperUserDictionary; },
   set whisperUserDictionary(value) { whisperUserDictionary = value; },
   get currentLLMProvider() { return currentLLMProvider; },
@@ -758,6 +764,7 @@ function initDebugHUD() {
     info.push('Recording: ' + (AppState.isRecording ? 'YES' : 'NO'));
     info.push('STT: ' + (AppState.currentSTTProvider ? 'active' : 'none'));
     info.push('Queue: ' + transcriptionQueue.length);
+    info.push('Dropped: ' + (AppState.transcriptionQueueOverflow.discardedChunks || 0));
     info.push('Chunks: ' + AppState.transcriptChunks.length);
     info.push('Stream: ' + (AppState.currentAudioStream ? 'active' : 'null'));
     info.push('---');
@@ -1762,6 +1769,7 @@ async function startRecording() {
   clearRecorderRestartTimeout();
   AppState.activeProviderId = provider;
   AppState.activeProviderStartArgs = null;
+  AppState.transcriptionQueueOverflow = TranscriptionQueueOverflowService.createInitialState();
 
   // 一時取得したストリームをcurrentAudioStreamに引き継ぐ
   AppState.currentAudioStream = tempAudioStream;
@@ -2606,14 +2614,52 @@ async function processCompleteBlob(audioBlob) {
   transcriptionQueue.push(audioBlob);
   console.log(`[Blob Enqueue] id=${blobId}, queue length:`, transcriptionQueue.length);
 
-  // キューが溜まりすぎたら古いのを捨てる（リアルタイム優先）
-  while (transcriptionQueue.length > 3) {
-    const dropped = transcriptionQueue.shift();
-    console.log('Dropped old blob from queue, size:', dropped.size);
+  const overflow = TranscriptionQueueOverflowService.discardOverflow(
+    transcriptionQueue,
+    TRANSCRIPTION_QUEUE_MAX_LENGTH
+  );
+  if (overflow.discardedCount > 0) {
+    handleTranscriptionQueueOverflow(overflow);
   }
 
   // キュー処理を開始
   processQueue();
+}
+
+function handleTranscriptionQueueOverflow(overflow) {
+  const now = Date.now();
+  AppState.transcriptionQueueOverflow = TranscriptionQueueOverflowService.recordDiscardedChunks(
+    AppState.transcriptionQueueOverflow,
+    overflow.discarded,
+    now
+  );
+
+  console.warn('[Transcription Queue] Overflow: discarded audio chunks', {
+    discardedCount: overflow.discardedCount,
+    totalDiscarded: AppState.transcriptionQueueOverflow.discardedChunks,
+    queueLength: overflow.queueLength,
+    maxQueueLength: overflow.maxQueueLength,
+    lastDiscardedBlobId: AppState.transcriptionQueueOverflow.lastDiscardedBlobId,
+    lastDiscardedSize: AppState.transcriptionQueueOverflow.lastDiscardedSize
+  });
+
+  const message = TranscriptionQueueOverflowService.buildDiscardMessage(
+    AppState.transcriptionQueueOverflow,
+    I18n.getLanguage()
+  );
+  updateStatusBadge(message, 'error');
+
+  if (TranscriptionQueueOverflowService.shouldNotify(
+    AppState.transcriptionQueueOverflow,
+    now,
+    TRANSCRIPTION_QUEUE_OVERFLOW_TOAST_COOLDOWN_MS
+  )) {
+    showToast(message, 'warning');
+    AppState.transcriptionQueueOverflow = TranscriptionQueueOverflowService.markNotified(
+      AppState.transcriptionQueueOverflow,
+      now
+    );
+  }
 }
 
 // キュー完了待機用のPromise解決関数

--- a/js/services/transcription-queue-overflow-service.js
+++ b/js/services/transcription-queue-overflow-service.js
@@ -1,0 +1,105 @@
+const TranscriptionQueueOverflowService = (function () {
+  'use strict';
+
+  const DEFAULT_MAX_QUEUE_LENGTH = 3;
+  const DEFAULT_NOTIFICATION_COOLDOWN_MS = 15000;
+
+  function createInitialState() {
+    return {
+      discardedChunks: 0,
+      lastDiscardedAt: null,
+      lastDiscardedBlobId: null,
+      lastDiscardedSize: 0,
+      lastWarningAt: 0
+    };
+  }
+
+  function normalizeMaxQueueLength(maxQueueLength) {
+    if (!Number.isFinite(maxQueueLength) || maxQueueLength < 1) {
+      return DEFAULT_MAX_QUEUE_LENGTH;
+    }
+    return Math.floor(maxQueueLength);
+  }
+
+  function snapshotChunk(chunk) {
+    return {
+      id: chunk && chunk._debugId ? chunk._debugId : 'unknown',
+      size: chunk && Number.isFinite(chunk.size) ? chunk.size : 0,
+      duration: chunk && Number.isFinite(chunk._duration) ? chunk._duration : null,
+      enqueueTime: chunk && Number.isFinite(chunk._enqueueTime) ? chunk._enqueueTime : null
+    };
+  }
+
+  function discardOverflow(queue, maxQueueLength) {
+    const limit = normalizeMaxQueueLength(maxQueueLength);
+    const discarded = [];
+    if (!Array.isArray(queue)) {
+      return { discarded, discardedCount: 0, queueLength: 0, maxQueueLength: limit };
+    }
+
+    while (queue.length > limit) {
+      discarded.push(snapshotChunk(queue.shift()));
+    }
+
+    return {
+      discarded,
+      discardedCount: discarded.length,
+      queueLength: queue.length,
+      maxQueueLength: limit
+    };
+  }
+
+  function recordDiscardedChunks(state, discarded, now) {
+    const current = state || createInitialState();
+    const items = Array.isArray(discarded) ? discarded : [];
+    if (items.length === 0) return current;
+
+    const last = items[items.length - 1];
+    return {
+      discardedChunks: (Number(current.discardedChunks) || 0) + items.length,
+      lastDiscardedAt: Number.isFinite(now) ? now : Date.now(),
+      lastDiscardedBlobId: last.id || 'unknown',
+      lastDiscardedSize: Number.isFinite(last.size) ? last.size : 0,
+      lastWarningAt: Number(current.lastWarningAt) || 0
+    };
+  }
+
+  function shouldNotify(state, now, cooldownMs) {
+    const current = state || createInitialState();
+    const timestamp = Number.isFinite(now) ? now : Date.now();
+    const cooldown = Number.isFinite(cooldownMs) ? cooldownMs : DEFAULT_NOTIFICATION_COOLDOWN_MS;
+    return !current.lastWarningAt || timestamp - current.lastWarningAt >= cooldown;
+  }
+
+  function markNotified(state, now) {
+    const current = state || createInitialState();
+    return {
+      ...current,
+      lastWarningAt: Number.isFinite(now) ? now : Date.now()
+    };
+  }
+
+  function buildDiscardMessage(state, language) {
+    const current = state || createInitialState();
+    const count = Number(current.discardedChunks) || 0;
+    if (language === 'en') {
+      return `Transcription is delayed. ${count} audio chunk(s) were discarded.`;
+    }
+    return `文字起こし処理が遅延しています。音声チャンク ${count} 件を破棄しました。`;
+  }
+
+  return {
+    DEFAULT_MAX_QUEUE_LENGTH,
+    DEFAULT_NOTIFICATION_COOLDOWN_MS,
+    createInitialState,
+    discardOverflow,
+    recordDiscardedChunks,
+    shouldNotify,
+    markNotified,
+    buildDiscardMessage
+  };
+})();
+
+if (typeof window !== 'undefined') {
+  window.TranscriptionQueueOverflowService = TranscriptionQueueOverflowService;
+}

--- a/tests/unit/transcription-queue-overflow-service.test.mjs
+++ b/tests/unit/transcription-queue-overflow-service.test.mjs
@@ -1,0 +1,62 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadScript } from '../helpers/load-script.mjs';
+
+function loadService() {
+  return loadScript('js/services/transcription-queue-overflow-service.js').TranscriptionQueueOverflowService;
+}
+
+describe('TranscriptionQueueOverflowService', () => {
+  it('discards oldest chunks until the queue is within the max length', () => {
+    const service = loadService();
+    const queue = [
+      { _debugId: 'blob-1', size: 1000, _duration: 1, _enqueueTime: 10 },
+      { _debugId: 'blob-2', size: 2000, _duration: 2, _enqueueTime: 20 },
+      { _debugId: 'blob-3', size: 3000, _duration: 3, _enqueueTime: 30 },
+      { _debugId: 'blob-4', size: 4000, _duration: 4, _enqueueTime: 40 }
+    ];
+
+    const result = service.discardOverflow(queue, 3);
+
+    assert.equal(result.discardedCount, 1);
+    assert.equal(result.discarded[0].id, 'blob-1');
+    assert.deepEqual(queue.map((item) => item._debugId), ['blob-2', 'blob-3', 'blob-4']);
+    assert.equal(result.queueLength, 3);
+  });
+
+  it('records discarded chunk totals and last discarded metadata', () => {
+    const service = loadService();
+    const state = service.recordDiscardedChunks(
+      service.createInitialState(),
+      [
+        { id: 'blob-1', size: 1000 },
+        { id: 'blob-2', size: 2000 }
+      ],
+      12345
+    );
+
+    assert.equal(state.discardedChunks, 2);
+    assert.equal(state.lastDiscardedAt, 12345);
+    assert.equal(state.lastDiscardedBlobId, 'blob-2');
+    assert.equal(state.lastDiscardedSize, 2000);
+  });
+
+  it('throttles repeated warning notifications', () => {
+    const service = loadService();
+    const state = service.markNotified(service.createInitialState(), 1000);
+
+    assert.equal(service.shouldNotify(state, 2000, 15000), false);
+    assert.equal(service.shouldNotify(state, 17000, 15000), true);
+  });
+
+  it('builds a user-visible discarded count message', () => {
+    const service = loadService();
+    const state = {
+      ...service.createInitialState(),
+      discardedChunks: 3
+    };
+
+    assert.match(service.buildDiscardMessage(state, 'ja'), /3 件を破棄/);
+    assert.match(service.buildDiscardMessage(state, 'en'), /3 audio chunk\(s\) were discarded/);
+  });
+});


### PR DESCRIPTION
## Summary
- Replace silent transcription queue overflow drops with explicit overflow handling
- Keep the real-time queue capped at 3 chunks while tracking total discarded chunks and last discarded metadata
- Show a warning toast and status badge message when chunks are discarded
- Throttle repeated overflow toasts to avoid notification spam
- Add debug HUD visibility for discarded chunk count
- Add unit coverage for overflow trimming, discard counters, notification throttling, and user-visible messages

## Scope
This PR intentionally does not implement IndexedDB retry/failed chunk persistence yet. It removes the silent-loss behavior first while preserving the existing bounded queue policy.

## Validation
- `npm run test:unit`: passed, 180 tests
- `npm run lint`: passed with existing 8 warnings
- `git diff --check`: passed
- `npm run test:ui-smoke`: passed
- `npm test`: fails on existing `test-upload-edge / test-12mb.txt (size reject)` behavior after generated fixtures; actual result is `{status:"fail", charCount:2000, warning:"TRUNCATED"}` instead of expected reject success. This is the same known upload-edge failure class noted before and is unrelated to this queue overflow change.

## Manual behavior notes
- When the queue exceeds 3 chunks, oldest chunks are still dropped to preserve the existing real-time policy.
- Dropped chunks now produce `console.warn`, visible status badge text, and a warning toast.
- Cumulative discarded count remains in app state for the session and is visible in the debug HUD.

## Notes for reviewers
- Follow-up PR can add bounded IndexedDB `failedTranscriptionChunks` persistence and retry UX. This PR keeps the blast radius small: no replay system, no app.js split, no recording pipeline rewrite.