### PR TITLE
fix: retry transient HTTP responses

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,6 +39,7 @@ export default [
         LLMClientService: 'readonly',
         MeetingContextService: 'readonly',
         TranscriptionQueueOverflowService: 'readonly',
+        FetchRetryService: 'readonly',
         ExportService: 'readonly',
         DiagnosticsService: 'readonly',
         STTProviders: 'writable',

--- a/index.html
+++ b/index.html
@@ -734,6 +734,7 @@
   <script src="js/services/meeting-context-service.js" defer></script>
   <script src="js/services/active-meeting-draft-service.js" defer></script>
   <script src="js/services/transcription-queue-overflow-service.js" defer></script>
+  <script src="js/services/fetch-retry-service.js" defer></script>
   <script src="js/services/export-service.js" defer></script>
   <script src="js/services/diagnostics-service.js" defer></script>
   <!-- メインアプリ -->

--- a/js/app.js
+++ b/js/app.js
@@ -2982,35 +2982,7 @@ function showToast(message, type = 'info') {
 // リトライ機能付きAPI呼び出し
 // =====================================
 async function fetchWithRetry(url, options, maxRetries = 3) {
-  let lastError;
-
-  for (let i = 0; i < maxRetries; i++) {
-    try {
-      // AbortSignalがabortedの場合は即座にエラーを投げる (#50)
-      if (options.signal && options.signal.aborted) {
-        const err = new Error('Request aborted');
-        err.name = 'AbortError';
-        throw err;
-      }
-      const response = await fetch(url, options);
-      return response;
-    } catch (error) {
-      // AbortErrorの場合はリトライせず即座に投げる (#50)
-      if (error.name === 'AbortError') {
-        throw error;
-      }
-      lastError = error;
-      console.warn(`API呼び出し失敗 (${i + 1}/${maxRetries}):`, error);
-
-      if (i < maxRetries - 1) {
-        // 指数バックオフ: 1秒, 2秒, 4秒
-        const delay = Math.pow(2, i) * 1000;
-        await new Promise(resolve => setTimeout(resolve, delay));
-      }
-    }
-  }
-
-  throw lastError;
+  return FetchRetryService.fetchWithRetry(url, options, { maxAttempts: maxRetries });
 }
 
 // =====================================

--- a/js/services/fetch-retry-service.js
+++ b/js/services/fetch-retry-service.js
@@ -1,0 +1,105 @@
+const FetchRetryService = (function () {
+  'use strict';
+
+  const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
+  const DEFAULT_MAX_ATTEMPTS = 3;
+  const MAX_RETRY_AFTER_MS = 8000;
+
+  function isRetryableStatus(status) {
+    return RETRYABLE_STATUS_CODES.has(status);
+  }
+
+  function parseRetryAfterMs(value, nowMs) {
+    if (!value) return null;
+
+    const seconds = Number(value);
+    if (Number.isFinite(seconds) && seconds >= 0) {
+      return Math.min(seconds * 1000, MAX_RETRY_AFTER_MS);
+    }
+
+    const retryAt = Date.parse(value);
+    if (Number.isNaN(retryAt)) return null;
+
+    const delay = retryAt - (Number.isFinite(nowMs) ? nowMs : Date.now());
+    return Math.min(Math.max(delay, 0), MAX_RETRY_AFTER_MS);
+  }
+
+  function getRetryAfterMs(response, nowMs) {
+    const headers = response && response.headers;
+    if (!headers || typeof headers.get !== 'function') return null;
+    return parseRetryAfterMs(headers.get('Retry-After'), nowMs);
+  }
+
+  function getBackoffDelayMs(attemptIndex) {
+    return Math.pow(2, attemptIndex) * 1000;
+  }
+
+  function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  async function fetchWithRetry(url, options, settings) {
+    const config = settings || {};
+    const maxAttempts = Number.isFinite(config.maxAttempts) && config.maxAttempts > 0
+      ? Math.floor(config.maxAttempts)
+      : DEFAULT_MAX_ATTEMPTS;
+    const fetchImpl = config.fetchImpl || fetch;
+    const sleepImpl = config.sleepImpl || sleep;
+    const nowImpl = config.nowImpl || Date.now;
+    const logger = Object.prototype.hasOwnProperty.call(config, 'logger')
+      ? config.logger
+      : console;
+    let lastError;
+
+    for (let attemptIndex = 0; attemptIndex < maxAttempts; attemptIndex++) {
+      try {
+        if (options && options.signal && options.signal.aborted) {
+          const err = new Error('Request aborted');
+          err.name = 'AbortError';
+          throw err;
+        }
+
+        const response = await fetchImpl(url, options);
+        if (!response || !isRetryableStatus(response.status) || attemptIndex >= maxAttempts - 1) {
+          return response;
+        }
+
+        const retryAfterMs = getRetryAfterMs(response, nowImpl());
+        const delay = retryAfterMs != null ? retryAfterMs : getBackoffDelayMs(attemptIndex);
+        if (logger && typeof logger.warn === 'function') {
+          logger.warn(`HTTP ${response.status}; retrying API call (${attemptIndex + 1}/${maxAttempts})`);
+        }
+        await sleepImpl(delay);
+      } catch (error) {
+        if (error.name === 'AbortError') {
+          throw error;
+        }
+
+        lastError = error;
+        if (logger && typeof logger.warn === 'function') {
+          logger.warn(`API呼び出し失敗 (${attemptIndex + 1}/${maxAttempts}):`, error);
+        }
+
+        if (attemptIndex < maxAttempts - 1) {
+          await sleepImpl(getBackoffDelayMs(attemptIndex));
+        }
+      }
+    }
+
+    throw lastError;
+  }
+
+  return {
+    RETRYABLE_STATUS_CODES,
+    MAX_RETRY_AFTER_MS,
+    isRetryableStatus,
+    parseRetryAfterMs,
+    getRetryAfterMs,
+    getBackoffDelayMs,
+    fetchWithRetry
+  };
+})();
+
+if (typeof window !== 'undefined') {
+  window.FetchRetryService = FetchRetryService;
+}

--- a/tests/unit/fetch-retry-service.test.mjs
+++ b/tests/unit/fetch-retry-service.test.mjs
@@ -1,0 +1,153 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadScript } from '../helpers/load-script.mjs';
+
+function loadService() {
+  return loadScript('js/services/fetch-retry-service.js').FetchRetryService;
+}
+
+function createResponse(status, retryAfter = null) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: {
+      get(name) {
+        return name.toLowerCase() === 'retry-after' ? retryAfter : null;
+      }
+    }
+  };
+}
+
+describe('FetchRetryService', () => {
+  it('retries HTTP 429 responses and returns the eventual success response', async () => {
+    const service = loadService();
+    const calls = [];
+    const delays = [];
+    const finalResponse = createResponse(200);
+
+    const result = await service.fetchWithRetry('https://example.test', {}, {
+      maxAttempts: 3,
+      logger: null,
+      sleepImpl: async (ms) => { delays.push(ms); },
+      fetchImpl: async () => {
+        calls.push(Date.now());
+        return calls.length === 1 ? createResponse(429) : finalResponse;
+      }
+    });
+
+    assert.equal(result, finalResponse);
+    assert.equal(calls.length, 2);
+    assert.deepEqual(delays, [1000]);
+  });
+
+  it('retries HTTP 503 responses', async () => {
+    const service = loadService();
+    let calls = 0;
+
+    const result = await service.fetchWithRetry('https://example.test', {}, {
+      maxAttempts: 3,
+      logger: null,
+      sleepImpl: async () => {},
+      fetchImpl: async () => {
+        calls += 1;
+        return calls < 3 ? createResponse(503) : createResponse(200);
+      }
+    });
+
+    assert.equal(result.status, 200);
+    assert.equal(calls, 3);
+  });
+
+  it('does not retry HTTP 401 or 403 responses', async () => {
+    const service = loadService();
+
+    for (const status of [401, 403]) {
+      let calls = 0;
+      const result = await service.fetchWithRetry('https://example.test', {}, {
+        maxAttempts: 3,
+        logger: null,
+        sleepImpl: async () => {},
+        fetchImpl: async () => {
+          calls += 1;
+          return createResponse(status);
+        }
+      });
+
+      assert.equal(result.status, status);
+      assert.equal(calls, 1);
+    }
+  });
+
+  it('does not retry HTTP 404 or 422 responses', async () => {
+    const service = loadService();
+
+    for (const status of [404, 422]) {
+      let calls = 0;
+      const result = await service.fetchWithRetry('https://example.test', {}, {
+        maxAttempts: 3,
+        logger: null,
+        sleepImpl: async () => {},
+        fetchImpl: async () => {
+          calls += 1;
+          return createResponse(status);
+        }
+      });
+
+      assert.equal(result.status, status);
+      assert.equal(calls, 1);
+    }
+  });
+
+  it('uses Retry-After seconds when present', async () => {
+    const service = loadService();
+    const delays = [];
+    let calls = 0;
+
+    await service.fetchWithRetry('https://example.test', {}, {
+      maxAttempts: 2,
+      logger: null,
+      sleepImpl: async (ms) => { delays.push(ms); },
+      fetchImpl: async () => {
+        calls += 1;
+        return calls === 1 ? createResponse(429, '2') : createResponse(200);
+      }
+    });
+
+    assert.deepEqual(delays, [2000]);
+  });
+
+  it('uses Retry-After HTTP-date when present', async () => {
+    const service = loadService();
+    const delays = [];
+    let calls = 0;
+
+    await service.fetchWithRetry('https://example.test', {}, {
+      maxAttempts: 2,
+      logger: null,
+      nowImpl: () => Date.parse('Sat, 13 Jun 2026 00:00:00 GMT'),
+      sleepImpl: async (ms) => { delays.push(ms); },
+      fetchImpl: async () => {
+        calls += 1;
+        return calls === 1
+          ? createResponse(503, 'Sat, 13 Jun 2026 00:00:03 GMT')
+          : createResponse(200);
+      }
+    });
+
+    assert.deepEqual(delays, [3000]);
+  });
+
+  it('does not retry aborted requests', async () => {
+    const service = loadService();
+    const signal = { aborted: true };
+
+    await assert.rejects(
+      () => service.fetchWithRetry('https://example.test', { signal }, {
+        maxAttempts: 3,
+        logger: null,
+        fetchImpl: async () => createResponse(200)
+      }),
+      { name: 'AbortError' }
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add `FetchRetryService` for retry behavior that is directly unit tested
- Keep the existing `fetchWithRetry(url, options, maxRetries)` app API and delegate to the service
- Retry HTTP 429 / 500 / 502 / 503 / 504 responses
- Do not retry HTTP 401 / 403 / 404 / 422 responses
- Respect `Retry-After` when it is a seconds value or HTTP-date, with an 8s cap
- Use short exponential backoff when `Retry-After` is absent
- Preserve AbortError behavior: aborted requests are not retried

## Scope control
- No Gemini API key auth changes
- No UI changes beyond loading the new service script
- No queue persistence or retry queue work
- No app.js split or ESM conversion

## Validation
- `npm run test:unit`: passed, 187 tests
- `npm run lint`: passed with existing 8 warnings
- `npm run test:ui-smoke`: passed
- `git diff --check`: passed

## Test coverage
- 429 retries and returns eventual success
- 503 retries
- 401 / 403 do not retry
- 404 / 422 do not retry
- Retry-After seconds is used
- Retry-After HTTP-date is used
- AbortError is not retried

## Notes for reviewers
This PR intentionally leaves Gemini query-param auth fallback untouched. That is planned for PR-5.