### PR TITLE
fix: use header auth for Gemini API keys

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2986,70 +2986,64 @@ async function fetchWithRetry(url, options, maxRetries = 3) {
 }
 
 // =====================================
-// Gemini API呼び出しヘルパー（v1 → v1beta, header → query フォールバック）
+// Gemini API呼び出しヘルパー（v1 → v1beta, header auth only）
 // =====================================
 async function callGeminiApi(model, apiKey, body, signal = null) {
   // Normalize model ID to prevent /models/models/... bug
   const normalizedModel = normalizeGeminiModelId(model);
 
   const apiVersions = ['v1', 'v1beta'];
-  const authMethods = ['header', 'query'];
   let lastError = null;
   let lastResponse = null;
 
   for (const version of apiVersions) {
-    for (const authMethod of authMethods) {
-      try {
-        let url = `https://generativelanguage.googleapis.com/${version}/models/${normalizedModel}:generateContent`;
-        const options = {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(body),
-          signal: signal
-        };
+    try {
+      const url = `https://generativelanguage.googleapis.com/${version}/models/${normalizedModel}:generateContent`;
+      const options = {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-goog-api-key': apiKey
+        },
+        body: JSON.stringify(body),
+        signal: signal
+      };
 
-        if (authMethod === 'header') {
-          options.headers['x-goog-api-key'] = apiKey;
-        } else {
-          url = `${url}?key=${encodeURIComponent(apiKey)}`;
-        }
+      console.log(`[Gemini] Trying ${version} with header auth`);
+      // Use fetchWithRetry for network resilience (429, CORS, transient errors)
+      const response = await fetchWithRetry(url, options, 2); // 2 retries per attempt
 
-        console.log(`[Gemini] Trying ${version} with ${authMethod} auth`);
-        // Use fetchWithRetry for network resilience (429, CORS, transient errors)
-        const response = await fetchWithRetry(url, options, 2); // 2 retries per attempt
-
-        if (response.ok) {
-          console.log(`[Gemini] Success with ${version} ${authMethod}`);
-          return response;
-        }
-
-        // 認証エラー（401/403）の場合はauth methodを変えて再試行
-        if (response.status === 401 || response.status === 403) {
-          console.warn(`[Gemini] Auth failed with ${version} ${authMethod}:`, response.status);
-          lastResponse = response;
-          continue;
-        }
-
-        // モデル関連エラー（404等）の場合はバージョンを変えて再試行
-        if (response.status === 404) {
-          console.warn(`[Gemini] Model not found in ${version}, trying next version`);
-          lastResponse = response;
-          break; // 次のバージョンへ
-        }
-
-        // その他のエラーはそのまま返す（rate limit等）
+      if (response.ok) {
+        console.log(`[Gemini] Success with ${version} header auth`);
         return response;
-      } catch (e) {
-        console.warn(`[Gemini] ${version} ${authMethod} failed:`, e.message);
-        lastError = e;
       }
+
+      // 認証エラー（401/403）の場合はレスポンスを保持して次バージョンへ進む
+      if (response.status === 401 || response.status === 403) {
+        console.warn(`[Gemini] Auth failed with ${version} header auth:`, response.status);
+        lastResponse = response;
+        continue;
+      }
+
+      // モデル関連エラー（404等）の場合はバージョンを変えて再試行
+      if (response.status === 404) {
+        console.warn(`[Gemini] Model not found in ${version}, trying next version`);
+        lastResponse = response;
+        continue; // 次のバージョンへ
+      }
+
+      // その他のエラーはそのまま返す（rate limit等）
+      return response;
+    } catch (e) {
+      console.warn(`[Gemini] ${version} header auth failed:`, e.message);
+      lastError = e;
     }
   }
 
   // 全て失敗した場合
   if (lastResponse) return lastResponse;
   if (lastError) throw lastError;
-  throw new Error('Gemini API call failed with all fallback methods');
+  throw new Error('Gemini API call failed with all API versions');
 }
 
 // =====================================

--- a/js/config.js
+++ b/js/config.js
@@ -525,8 +525,7 @@ async function validateApiKey(provider, key) {
 
     switch (provider) {
       case 'gemini':
-        // Try header auth first (more secure), fallback to ?key= if needed
-        // Try v1 first (stable), fallback to v1beta
+        // Try v1 first (stable), fallback to v1beta with header auth only.
         response = await tryGeminiAuth(key);
         break;
 
@@ -812,36 +811,30 @@ function getProviderName(provider) {
 }
 
 // =====================================
-// Gemini認証フォールバック
-// v1 → v1beta, header → ?key= の順で試行
+// Gemini認証
+// v1 → v1beta の順で試行し、APIキーは必ずヘッダーで送る
 // =====================================
 async function tryGeminiAuth(key) {
   const apiVersions = ['v1', 'v1beta'];
-  const authMethods = ['header', 'query'];
   let lastResponse = null;
 
   for (const version of apiVersions) {
-    for (const authMethod of authMethods) {
-      try {
-        let url = `https://generativelanguage.googleapis.com/${version}/models`;
-        const fetchOptions = { method: 'GET' };
+    try {
+      const url = `https://generativelanguage.googleapis.com/${version}/models`;
+      const fetchOptions = {
+        method: 'GET',
+        headers: { 'x-goog-api-key': key }
+      };
 
-        if (authMethod === 'header') {
-          fetchOptions.headers = { 'x-goog-api-key': key };
-        } else {
-          url = `${url}?key=${encodeURIComponent(key)}`;
-        }
-
-        const response = await fetch(url, fetchOptions);
-        lastResponse = response;
-        if (response.ok || response.status === 401 || response.status === 403) {
-          // Return on success or definite auth failure
-          return response;
-        }
-        // Continue trying on other errors
-      } catch (e) {
-        console.warn(`Gemini ${version} ${authMethod} auth failed:`, e.message);
+      const response = await fetch(url, fetchOptions);
+      lastResponse = response;
+      if (response.ok || response.status === 401 || response.status === 403) {
+        // Return on success or definite auth failure
+        return response;
       }
+      // Continue trying on other errors
+    } catch (e) {
+      console.warn(`Gemini ${version} header auth failed:`, e.message);
     }
   }
 

--- a/js/model-registry.js
+++ b/js/model-registry.js
@@ -270,8 +270,7 @@ const ModelRegistry = (function() {
 
   /**
    * Fetch models from provider API
-   * For Gemini: Try header auth first, fallback to ?key= query param
-   * For Gemini: Try v1 first, fallback to v1beta
+   * For Gemini: Try v1 first, fallback to v1beta with header auth only
    */
   async function fetchModels(provider, apiKey) {
     var config = PROVIDER_CONFIG[provider];
@@ -290,7 +289,7 @@ const ModelRegistry = (function() {
       return null;
     }
 
-    // Gemini: Try v1 first, then v1beta, with header → ?key= fallback
+    // Gemini: Try v1 first, then v1beta, with header auth only
     if (provider === 'gemini') {
       return await fetchGeminiModels(apiKey, config);
     }
@@ -335,46 +334,36 @@ const ModelRegistry = (function() {
   }
 
   /**
-   * Fetch Gemini models with v1 → v1beta and header → ?key= fallback
+   * Fetch Gemini models with v1 → v1beta and header auth only
    */
   async function fetchGeminiModels(apiKey, config) {
     // API versions to try: v1 first (stable), then v1beta
     var apiVersions = ['v1', 'v1beta'];
-    // Auth methods: header first (more secure), then query param (fallback)
-    var authMethods = ['header', 'query'];
 
     for (var vi = 0; vi < apiVersions.length; vi++) {
       var version = apiVersions[vi];
       var endpoint = 'https://generativelanguage.googleapis.com/' + version + '/models';
 
-      for (var ai = 0; ai < authMethods.length; ai++) {
-        var authMethod = authMethods[ai];
+      try {
+        var fetchOptions = {
+          method: 'GET',
+          headers: { 'x-goog-api-key': apiKey }
+        };
+        var url = endpoint;
 
-        try {
-          var fetchOptions = { method: 'GET' };
-          var url = endpoint;
+        console.log('[ModelRegistry] Trying Gemini', version, 'with header auth');
+        var response = await fetch(url, fetchOptions);
 
-          if (authMethod === 'header') {
-            fetchOptions.headers = { 'x-goog-api-key': apiKey };
-          } else {
-            // Query param fallback (less secure but works in some CORS-restricted environments)
-            url = endpoint + '?key=' + encodeURIComponent(apiKey);
-          }
-
-          console.log('[ModelRegistry] Trying Gemini', version, 'with', authMethod, 'auth');
-          var response = await fetch(url, fetchOptions);
-
-          if (response.ok) {
-            var data = await response.json();
-            var models = config.parseModels(data);
-            console.log('[ModelRegistry] Fetched', models.length, 'Gemini models via', version, authMethod);
-            return models;
-          }
-
-          console.warn('[ModelRegistry] Gemini', version, authMethod, 'returned', response.status);
-        } catch (e) {
-          console.warn('[ModelRegistry] Gemini', version, authMethod, 'failed:', e.message);
+        if (response.ok) {
+          var data = await response.json();
+          var models = config.parseModels(data);
+          console.log('[ModelRegistry] Fetched', models.length, 'Gemini models via', version, 'header auth');
+          return models;
         }
+
+        console.warn('[ModelRegistry] Gemini', version, 'header auth returned', response.status);
+      } catch (e) {
+        console.warn('[ModelRegistry] Gemini', version, 'header auth failed:', e.message);
       }
     }
 
@@ -533,14 +522,13 @@ const ModelRegistry = (function() {
   }
 
   /**
-   * Probe Gemini model with v1 → v1beta, header → query fallback
+   * Probe Gemini model with v1 → v1beta and header auth only
    */
   async function probeGeminiModel(model, apiKey) {
     // Normalize model ID to prevent /models/models/... bug
     var normalizedModel = normalizeGeminiModelId(model);
 
     var apiVersions = ['v1', 'v1beta'];
-    var authMethods = ['header', 'query'];
     var body = JSON.stringify({
       contents: [{ parts: [{ text: 'Hi' }] }],
       generationConfig: { maxOutputTokens: 1 }
@@ -552,59 +540,52 @@ const ModelRegistry = (function() {
     for (var vi = 0; vi < apiVersions.length; vi++) {
       var version = apiVersions[vi];
 
-      for (var ai = 0; ai < authMethods.length; ai++) {
-        var authMethod = authMethods[ai];
+      try {
+        var url = 'https://generativelanguage.googleapis.com/' + version + '/models/' + normalizedModel + ':generateContent';
+        var fetchOptions = {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-goog-api-key': apiKey
+          },
+          body: body
+        };
 
-        try {
-          var url = 'https://generativelanguage.googleapis.com/' + version + '/models/' + normalizedModel + ':generateContent';
-          var fetchOptions = {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: body
-          };
+        var response = await fetch(url, fetchOptions);
 
-          if (authMethod === 'header') {
-            fetchOptions.headers['x-goog-api-key'] = apiKey;
-          } else {
-            url = url + '?key=' + encodeURIComponent(apiKey);
-          }
-
-          var response = await fetch(url, fetchOptions);
-
-          if (response.ok) {
-            setModelHealth('gemini', normalizedModel, 'working');
-            return 'working';
-          }
-
-          // Auth errors - try next auth method (don't mark as dead!)
-          if (response.status === 401 || response.status === 403) {
-            gotAuthError = true;
-            continue;
-          }
-
-          // Model not found - try next API version
-          if (response.status === 404) {
-            gotModelNotFound = true;
-            break;
-          }
-
-          // Rate limit or server error
-          if (response.status === 429 || response.status >= 500) {
-            setModelHealth('gemini', normalizedModel, 'flaky', 'Rate limit or server error (' + response.status + ')');
-            return 'flaky';
-          }
-
-          // Check error message
-          var errorData = await response.json().catch(function() { return {}; });
-          var errorMsg = errorData.error?.message || 'Unknown error';
-
-          if (isModelNotFoundError({ message: errorMsg })) {
-            gotModelNotFound = true;
-            break; // Try next API version
-          }
-        } catch (e) {
-          console.warn('[ModelRegistry] Gemini probe', version, authMethod, 'failed:', e.message);
+        if (response.ok) {
+          setModelHealth('gemini', normalizedModel, 'working');
+          return 'working';
         }
+
+        // Auth errors are not model problems; try the next API version.
+        if (response.status === 401 || response.status === 403) {
+          gotAuthError = true;
+          continue;
+        }
+
+        // Model not found - try next API version
+        if (response.status === 404) {
+          gotModelNotFound = true;
+          continue;
+        }
+
+        // Rate limit or server error
+        if (response.status === 429 || response.status >= 500) {
+          setModelHealth('gemini', normalizedModel, 'flaky', 'Rate limit or server error (' + response.status + ')');
+          return 'flaky';
+        }
+
+        // Check error message
+        var errorData = await response.json().catch(function() { return {}; });
+        var errorMsg = errorData.error?.message || 'Unknown error';
+
+        if (isModelNotFoundError({ message: errorMsg })) {
+          gotModelNotFound = true;
+          continue; // Try next API version
+        }
+      } catch (e) {
+        console.warn('[ModelRegistry] Gemini probe', version, 'header auth failed:', e.message);
       }
     }
 
@@ -633,7 +614,7 @@ const ModelRegistry = (function() {
     var config = PROVIDER_CONFIG[provider];
     if (!config) return 'unknown';
 
-    // Gemini uses special fallback logic (v1 → v1beta, header → query)
+    // Gemini uses special fallback logic (v1 → v1beta, header auth only)
     if (provider === 'gemini') {
       return await probeGeminiModel(model, apiKey);
     }

--- a/tests/unit/gemini-header-auth.test.mjs
+++ b/tests/unit/gemini-header-auth.test.mjs
@@ -1,0 +1,152 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadScript } from '../helpers/load-script.mjs';
+
+const __dirname = resolve(fileURLToPath(import.meta.url), '..');
+const PROJECT_ROOT = resolve(__dirname, '../..');
+
+function createStorage(initial = {}) {
+  const store = new Map(Object.entries(initial));
+  return {
+    getItem(key) {
+      return store.has(key) ? store.get(key) : null;
+    },
+    setItem(key, value) {
+      store.set(key, String(value));
+    },
+    removeItem(key) {
+      store.delete(key);
+    }
+  };
+}
+
+function createJsonResponse(status, data) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      return data;
+    }
+  };
+}
+
+function loadModelRegistry(fetchImpl) {
+  const window = {};
+  const localStorage = createStorage();
+  const sandbox = loadScript('js/model-registry.js', {
+    fetch: fetchImpl,
+    localStorage,
+    window
+  });
+  return sandbox.ModelRegistry;
+}
+
+function assertGeminiRequestUsesHeaderAuth(call, apiKey) {
+  const url = new URL(call.url);
+  assert.equal(url.searchParams.has('key'), false);
+  assert.equal(call.url.includes(apiKey), false);
+  assert.equal(call.options.headers['x-goog-api-key'], apiKey);
+}
+
+describe('Gemini header-only API key authentication', () => {
+  it('keeps Gemini API keys out of URL query strings in protected source paths', () => {
+    for (const file of ['js/app.js', 'js/config.js', 'js/model-registry.js']) {
+      const source = readFileSync(resolve(PROJECT_ROOT, file), 'utf8');
+      assert.equal(source.includes('?key='), false, `${file} must not append Gemini API keys to URLs`);
+      assert.equal(source.includes("['header', 'query']"), false, `${file} must not restore query auth fallback`);
+      assert.equal(source.includes('header → query'), false, `${file} must not document query auth fallback`);
+      assert.equal(source.includes('header → ?key'), false, `${file} must not document query auth fallback`);
+    }
+  });
+
+  it('fetches Gemini model lists with x-goog-api-key and no key query parameter', async () => {
+    const apiKey = 'gemini-secret-key';
+    const calls = [];
+    const ModelRegistry = loadModelRegistry(async (url, options = {}) => {
+      calls.push({ url, options });
+      return createJsonResponse(200, {
+        models: [
+          {
+            name: 'models/gemini-2.5-flash',
+            displayName: 'Gemini 2.5 Flash',
+            supportedGenerationMethods: ['generateContent']
+          }
+        ]
+      });
+    });
+
+    const models = await ModelRegistry.fetchModels('gemini', apiKey);
+
+    assert.equal(models.length, 1);
+    assert.equal(models[0].id, 'gemini-2.5-flash');
+    assert.equal(calls.length, 1);
+    assertGeminiRequestUsesHeaderAuth(calls[0], apiKey);
+  });
+
+  it('keeps Gemini model list version fallback header-only', async () => {
+    const apiKey = 'gemini-secret-key';
+    const calls = [];
+    const ModelRegistry = loadModelRegistry(async (url, options = {}) => {
+      calls.push({ url, options });
+      if (calls.length === 1) {
+        return createJsonResponse(500, {});
+      }
+      return createJsonResponse(200, {
+        models: [
+          {
+            name: 'models/gemini-2.5-pro',
+            displayName: 'Gemini 2.5 Pro',
+            supportedGenerationMethods: ['generateContent']
+          }
+        ]
+      });
+    });
+
+    const models = await ModelRegistry.fetchModels('gemini', apiKey);
+
+    assert.equal(models.length, 1);
+    assert.equal(calls.length, 2);
+    assert.match(calls[0].url, /\/v1\/models$/);
+    assert.match(calls[1].url, /\/v1beta\/models$/);
+    calls.forEach(call => assertGeminiRequestUsesHeaderAuth(call, apiKey));
+  });
+
+  it('probes Gemini models with x-goog-api-key and no key query parameter', async () => {
+    const apiKey = 'gemini-secret-key';
+    const calls = [];
+    const ModelRegistry = loadModelRegistry(async (url, options = {}) => {
+      calls.push({ url, options });
+      return createJsonResponse(200, {});
+    });
+
+    const status = await ModelRegistry.probeModel('gemini', 'models/gemini-2.5-flash', apiKey);
+
+    assert.equal(status, 'working');
+    assert.equal(calls.length, 1);
+    assert.match(calls[0].url, /\/v1\/models\/gemini-2\.5-flash:generateContent$/);
+    assertGeminiRequestUsesHeaderAuth(calls[0], apiKey);
+  });
+
+  it('keeps Gemini probe version fallback header-only', async () => {
+    const apiKey = 'gemini-secret-key';
+    const calls = [];
+    const ModelRegistry = loadModelRegistry(async (url, options = {}) => {
+      calls.push({ url, options });
+      if (calls.length === 1) {
+        return createJsonResponse(404, { error: { message: 'model not found' } });
+      }
+      return createJsonResponse(200, {});
+    });
+
+    const status = await ModelRegistry.probeModel('gemini', 'gemini-2.5-flash', apiKey);
+
+    assert.equal(status, 'working');
+    assert.equal(calls.length, 2);
+    assert.match(calls[0].url, /\/v1\/models\/gemini-2\.5-flash:generateContent$/);
+    assert.match(calls[1].url, /\/v1beta\/models\/gemini-2\.5-flash:generateContent$/);
+    calls.forEach(call => assertGeminiRequestUsesHeaderAuth(call, apiKey));
+  });
+});


### PR DESCRIPTION
## Summary
- Remove Gemini URL query API-key authentication fallback from generation calls, settings validation, model listing, and model probe paths.
- Keep Gemini v1 -> v1beta version fallback, but send the API key only via `x-goog-api-key`.
- Add unit coverage that asserts Gemini requests do not include the API key in URL query parameters.

## Scope
- No fetchWithRetry changes.
- No UI changes.
- No app.js split.
- No API-key storage changes.
- No proxy introduction.

## Verification
- `npm run test:unit` passed: 192 tests.
- `npm run lint` passed with existing 8 warnings.
- `npm run test:ui-smoke` passed.
- `git diff --check` passed.

## Notes
- `npm ci` reported 3 audit findings (1 moderate, 2 high); not addressed because dependency remediation is outside PR-5 scope.