### PR TITLE
fix: gate debug audio duration decode

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -726,9 +726,21 @@ function navigateTo(target) {
 // =====================================
 // デバッグHUD（?debug パラメータ時のみ表示）
 // =====================================
+function isDebugModeEnabled() {
+  if (typeof DebugLogger !== 'undefined' && typeof DebugLogger.isEnabled === 'boolean') {
+    return DebugLogger.isEnabled;
+  }
+
+  try {
+    var urlParams = new URLSearchParams(window.location.search);
+    return urlParams.has('debug');
+  } catch (_) {
+    return false;
+  }
+}
+
 function initDebugHUD() {
-  var urlParams = new URLSearchParams(window.location.search);
-  if (!urlParams.has('debug')) return;
+  if (!isDebugModeEnabled()) return;
 
   var hud = document.createElement('div');
   hud.id = 'debugHUD';
@@ -2593,21 +2605,25 @@ async function processCompleteBlob(audioBlob) {
   audioBlob._debugId = blobId;
   audioBlob._enqueueTime = Date.now();
 
-  // Duration算出（デバッグ用）
-  let audioContext;
-  try {
-    audioContext = new AudioContext();
-    const arrayBuffer = await audioBlob.arrayBuffer();
-    const audioBuffer = await audioContext.decodeAudioData(arrayBuffer.slice(0));
-    audioBlob._duration = audioBuffer.duration;
-    console.log(`[Blob Created] id=${blobId}, size=${audioBlob.size}, duration=${audioBuffer.duration.toFixed(2)}s`);
-  } catch (e) {
-    console.log(`[Blob Created] id=${blobId}, size=${audioBlob.size}, duration=unknown (${e.message})`);
-  } finally {
-    // AudioContextを確実にcloseする（リーク防止）
-    if (audioContext) {
-      await audioContext.close().catch(() => {});
+  if (isDebugModeEnabled()) {
+    // Duration算出（デバッグ用）
+    let audioContext;
+    try {
+      audioContext = new AudioContext();
+      const arrayBuffer = await audioBlob.arrayBuffer();
+      const audioBuffer = await audioContext.decodeAudioData(arrayBuffer.slice(0));
+      audioBlob._duration = audioBuffer.duration;
+      console.log(`[Blob Created] id=${blobId}, size=${audioBlob.size}, duration=${audioBuffer.duration.toFixed(2)}s`);
+    } catch (e) {
+      console.log(`[Blob Created] id=${blobId}, size=${audioBlob.size}, duration=unknown (${e.message})`);
+    } finally {
+      // AudioContextを確実にcloseする（リーク防止）
+      if (audioContext) {
+        await audioContext.close().catch(() => {});
+      }
     }
+  } else {
+    console.log(`[Blob Created] id=${blobId}, size=${audioBlob.size}, duration=skipped (debug disabled)`);
   }
 
   // キューに追加

--- a/tests/unit/debug-audio-decode-gate.test.mjs
+++ b/tests/unit/debug-audio-decode-gate.test.mjs
@@ -1,0 +1,49 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = resolve(fileURLToPath(import.meta.url), '..');
+const PROJECT_ROOT = resolve(__dirname, '../..');
+
+function getFunctionSource(source, functionName) {
+  const start = source.indexOf(`function ${functionName}(`);
+  assert.notEqual(start, -1, `${functionName} must exist`);
+
+  const bodyStart = source.indexOf('{', start);
+  let depth = 0;
+  for (let i = bodyStart; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    if (source[i] === '}') depth--;
+    if (depth === 0) {
+      return source.slice(start, i + 1);
+    }
+  }
+
+  assert.fail(`Could not parse ${functionName}`);
+}
+
+describe('debug audio decode gate', () => {
+  it('limits processCompleteBlob audio duration decoding to debug mode', () => {
+    const source = readFileSync(resolve(PROJECT_ROOT, 'js/app.js'), 'utf8');
+    const functionSource = getFunctionSource(source, 'processCompleteBlob');
+    const decodeIndex = functionSource.indexOf('decodeAudioData');
+    const gateIndex = functionSource.indexOf('if (isDebugModeEnabled())');
+
+    assert.notEqual(decodeIndex, -1, 'processCompleteBlob should still support debug duration decode');
+    assert.notEqual(gateIndex, -1, 'processCompleteBlob must gate debug duration decode');
+    assert.ok(gateIndex < decodeIndex, 'debug gate must appear before decodeAudioData');
+    assert.match(functionSource, /duration=skipped \(debug disabled\)/);
+  });
+
+  it('uses the same debug predicate for the debug HUD and audio duration decode', () => {
+    const source = readFileSync(resolve(PROJECT_ROOT, 'js/app.js'), 'utf8');
+    const hudSource = getFunctionSource(source, 'initDebugHUD');
+    const blobSource = getFunctionSource(source, 'processCompleteBlob');
+
+    assert.match(source, /function isDebugModeEnabled\(\)/);
+    assert.match(hudSource, /if \(!isDebugModeEnabled\(\)\) return;/);
+    assert.match(blobSource, /if \(isDebugModeEnabled\(\)\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a shared debug-mode predicate for `?debug` behavior.
- Limit the expensive audio duration `decodeAudioData` path in `processCompleteBlob` to debug mode only.
- Keep normal transcription queue behavior unchanged; non-debug blobs are enqueued without decoding audio for debug duration metadata.
- Add a unit regression test that ensures `decodeAudioData` remains behind the debug gate.

## Scope
- PR-6A only: debug audio decode gating.
- No UI refresh.
- No app.js split.
- No queue persistence changes.
- No fetchWithRetry changes.
- No API-key or provider auth changes.

## Verification
- `npm run test:unit` passed: 194 tests.
- `npm run lint` passed with existing 8 warnings.
- `npm run test:ui-smoke` passed.
- `git diff --check` passed.

## Notes
- `npm ci` reported 3 audit findings (1 moderate, 2 high); not addressed because dependency remediation is outside PR-6A scope.