### PR TITLE
fix: remove unused code

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -44,7 +44,6 @@ export default [
         DiagnosticsService: 'readonly',
         STTProviders: 'writable',
         PCMStreamProcessor: 'writable',
-        AudioResampler: 'writable',
         DeepgramWSProvider: 'writable',
         OpenAIChunkedProvider: 'writable',
         // Cross-file references used with typeof checks

--- a/js/app.js
+++ b/js/app.js
@@ -26,7 +26,6 @@ let finalStopResolve = null;
 let recorderStopReason = null;
 let recorderRestartTimeoutId = null;
 let activeProviderId = null;
-let activeProviderStartArgs = null;
 let activeMeetingDraftId = null;
 let activeMeetingDraftStartedAt = null;
 let activeMeetingDraftSaveTimer = null;
@@ -47,8 +46,6 @@ const CONTEXT_MAX_CHARS = 8000;           // 総文字数制限
 const CONTEXT_MAX_FILE_SIZE_MB = 20;      // ファイルサイズ上限（MB）
 const CONTEXT_MAX_FILES = 5;              // 最大ファイル数
 const CONTEXT_MAX_CHARS_PER_FILE = 2000;  // ファイルごとの文字数上限
-const CONTEXT_SUPPORTED_TYPES = ['text/plain', 'text/markdown'];
-const CONTEXT_SUPPORTED_EXTENSIONS = ['.txt', '.md'];
 
 const AI_WORK_ORDER_MODULES_PATH = 'modules/work-order-modules.json';
 const AI_WORK_ORDER_MODULES_FALLBACK = [
@@ -195,8 +192,6 @@ const AppState = {
   set recorderRestartTimeoutId(value) { recorderRestartTimeoutId = value; },
   get activeProviderId() { return activeProviderId; },
   set activeProviderId(value) { activeProviderId = value; },
-  get activeProviderStartArgs() { return activeProviderStartArgs; },
-  set activeProviderStartArgs(value) { activeProviderStartArgs = value; },
   get activeMeetingDraftId() { return activeMeetingDraftId; },
   set activeMeetingDraftId(value) { activeMeetingDraftId = value; },
   get activeMeetingDraftStartedAt() { return activeMeetingDraftStartedAt; },
@@ -285,7 +280,6 @@ var deepCopy = FormatUtils.deepCopy;
 var getCapabilities = CapabilityUtils.getCapabilities;
 var normalizeCapabilityProvider = CapabilityUtils.normalizeCapabilityProvider;
 var resolveEffectiveLlmProvider = CapabilityUtils.resolveEffectiveLlmProvider;
-var isReasoningCapableModel = CapabilityUtils.isReasoningCapableModel;
 
 // --- Sanitize utilities (delegated to js/lib/sanitize-utils.js) ---
 var sanitizeErrorLog = SanitizeUtils.sanitizeErrorLog;
@@ -411,9 +405,6 @@ const ALLOWED_STT_PROVIDERS = new Set(
     ? ProviderCatalog.getSttProviderIds()
     : ['openai_stt', 'deepgram_realtime']
 );
-
-// chunked系プロバイダー
-const CHUNKED_PROVIDERS = new Set(['openai_stt']);
 
 // streaming系プロバイダー
 const STREAMING_PROVIDERS = new Set([
@@ -1780,7 +1771,6 @@ async function startRecording() {
   AppState.recorderStopReason = null;
   clearRecorderRestartTimeout();
   AppState.activeProviderId = provider;
-  AppState.activeProviderStartArgs = null;
   AppState.transcriptionQueueOverflow = TranscriptionQueueOverflowService.createInitialState();
 
   // 一時取得したストリームをcurrentAudioStreamに引き継ぐ
@@ -2396,7 +2386,6 @@ async function stopRecording() {
   AppState.isPaused = false;
   AppState.recorderStopReason = 'stop';
   clearRecorderRestartTimeout();
-  AppState.activeProviderStartArgs = null;
 
   // クリーンアップ処理を呼び出し
   await cleanupRecording();
@@ -2475,7 +2464,7 @@ async function resumeRecording() {
       if (!AppState.currentSTTProvider || typeof AppState.currentSTTProvider.start !== 'function') {
         throw new Error('STT provider is not available');
       }
-      await AppState.currentSTTProvider.start(...(AppState.activeProviderStartArgs || []));
+      await AppState.currentSTTProvider.start();
     } else {
       if (!AppState.mediaRecorder || AppState.mediaRecorder.state === 'inactive') {
         startNewMediaRecorder();
@@ -3584,7 +3573,6 @@ function updateUI() {
   const pauseBtn = document.getElementById('pauseBtn');
   const badge = document.getElementById('statusBadge');
   const floatingBtn = document.getElementById('floatingStopBtn');
-  const meetingModeToggle = document.getElementById('meetingModeToggle');
   const meetingModeText = document.getElementById('meetingModeStatusText');
   const minutesBtn = document.getElementById('minutesBtn');
 
@@ -4527,9 +4515,6 @@ const LLM_PROVIDERS_FALLBACK = {
     hint: '<a href="https://console.groq.com/keys" target="_blank" rel="noopener">Groq Console</a>でAPIキーを取得'
   }
 };
-
-// Alias for backward compatibility
-const LLM_PROVIDERS = LLM_PROVIDERS_FALLBACK;
 
 let currentLLMProvider = 'gemini';
 

--- a/js/audio/pcm_stream.js
+++ b/js/audio/pcm_stream.js
@@ -227,41 +227,5 @@ class PCMStreamProcessor {
   }
 }
 
-/**
- * リサンプラー（異なるサンプルレート間の変換）
- */
-class AudioResampler {
-  constructor(fromRate, toRate) {
-    this.fromRate = fromRate;
-    this.toRate = toRate;
-    this.ratio = toRate / fromRate;
-  }
-
-  /**
-   * リサンプル（線形補間）
-   */
-  resample(inputArray) {
-    if (this.fromRate === this.toRate) {
-      return inputArray;
-    }
-
-    const outputLength = Math.ceil(inputArray.length * this.ratio);
-    const output = new Float32Array(outputLength);
-
-    for (let i = 0; i < outputLength; i++) {
-      const srcIndex = i / this.ratio;
-      const srcIndexFloor = Math.floor(srcIndex);
-      const srcIndexCeil = Math.min(srcIndexFloor + 1, inputArray.length - 1);
-      const fraction = srcIndex - srcIndexFloor;
-
-      output[i] = inputArray[srcIndexFloor] * (1 - fraction) +
-                  inputArray[srcIndexCeil] * fraction;
-    }
-
-    return output;
-  }
-}
-
 // グローバルに公開
 window.PCMStreamProcessor = PCMStreamProcessor;
-window.AudioResampler = AudioResampler;

--- a/js/model-registry.js
+++ b/js/model-registry.js
@@ -513,15 +513,6 @@ const ModelRegistry = (function() {
   }
 
   /**
-   * Check if health entry is still valid
-   */
-  function isHealthValid(healthEntry) {
-    if (!healthEntry) return false;
-    var age = Date.now() - (healthEntry.testedAt || 0);
-    return age < HEALTH_TTL;
-  }
-
-  /**
    * Probe Gemini model with v1 → v1beta and header auth only
    */
   async function probeGeminiModel(model, apiKey) {


### PR DESCRIPTION
## Summary
- Remove unused app-level constants and aliases flagged by lint/reference checks.
- Remove `activeProviderStartArgs`, which was only ever set to `null`; resume now calls the current STT provider with its existing no-arg `start()` signature.
- Remove unused `AudioResampler` and its eslint global entry.
- Remove unused `ModelRegistry` health-validity helper.

## Scope
- PR-6B only: unused variable and dead-code removal.
- No UI changes.
- No app.js split.
- No recording pipeline behavior changes beyond deleting unused no-op argument plumbing.
- No fetchWithRetry, Gemini auth, or queue persistence changes.

## Checked But Kept
- `isProcessingQueue`, `blobCounter`, and `lastTranscriptTail` are still used through `AppState`.
- `SecureStorage` remains as a browser global used by other scripts, even though eslint still reports its defining file as one existing global-style warning.

## Verification
- `npm run test:unit` passed: 194 tests.
- `npm run lint` passed with 1 warning (`SecureStorage` global definition).
- `npm run test:ui-smoke` passed.
- `git diff --check` passed.

## Notes
- `npm ci` reported 3 audit findings (1 moderate, 2 high); not addressed because dependency remediation is outside PR-6B scope.