### PR TITLE
fix: scope ask ai selection text

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,6 +32,7 @@ export default [
         SanitizeUtils: 'readonly',
         ModelUtils: 'readonly',
         TextUtils: 'readonly',
+        SelectionUtils: 'readonly',
         ProviderCatalog: 'readonly',
         MeetingTitleStore: 'readonly',
         MeetingContextStore: 'readonly',

--- a/index.html
+++ b/index.html
@@ -729,6 +729,8 @@
   <script src="js/lib/model-utils.js" defer></script>
   <!-- テキストユーティリティ -->
   <script src="js/lib/text-utils.js" defer></script>
+  <!-- 選択範囲ユーティリティ -->
+  <script src="js/lib/selection-utils.js" defer></script>
   <!-- サービス層（DOM非依存ロジック） -->
   <script src="js/services/llm-client.js" defer></script>
   <script src="js/services/meeting-context-service.js" defer></script>

--- a/js/app.js
+++ b/js/app.js
@@ -3093,6 +3093,66 @@ function getAvailableLlm() {
 // =====================================
 // AI質問機能
 // =====================================
+const AI_SELECTION_ALLOWED_SELECTORS = [
+  '#transcriptText .transcript-chunk',
+  '#memoListInTab .timeline-item-content',
+  '#memoListInTab .timeline-item-quote',
+  '#timelineList .timeline-item-content',
+  '#timelineList .timeline-item-quote',
+  '.ai-response[data-selection-content="true"]',
+  '.qa-question',
+  '.qa-answer',
+  '#contextGoalInput',
+  '#contextParticipantsInput',
+  '#contextHandoffInput',
+  '#contextReferenceInput'
+];
+
+const TRANSCRIPT_SELECTION_ALLOWED_SELECTORS = [
+  '#transcriptText .transcript-chunk'
+];
+
+const CONTENT_SELECTION_BLOCKED_SELECTORS = [
+  'button',
+  '[role="button"]',
+  'input',
+  'select',
+  'option',
+  'label',
+  '.btn',
+  '.btn-icon',
+  '.tab',
+  '.main-tab',
+  '.timeline-filter',
+  '.chunk-actions',
+  '.timeline-item-actions',
+  '.panel-header',
+  '.modal-header',
+  '.modal-footer',
+  '.toast',
+  '.status-badge',
+  '.llm-indicator',
+  '.cost-chip',
+  '.cost-display',
+  '.empty-state'
+];
+
+function getAllowedAISelectionText() {
+  if (typeof SelectionUtils === 'undefined') return '';
+  return SelectionUtils.getAllowedSelectionText({
+    allowedSelectors: AI_SELECTION_ALLOWED_SELECTORS,
+    blockedSelectors: CONTENT_SELECTION_BLOCKED_SELECTORS
+  });
+}
+
+function getAllowedTranscriptSelectionText() {
+  if (typeof SelectionUtils === 'undefined') return '';
+  return SelectionUtils.getAllowedSelectionText({
+    allowedSelectors: TRANSCRIPT_SELECTION_ALLOWED_SELECTORS,
+    blockedSelectors: CONTENT_SELECTION_BLOCKED_SELECTORS
+  });
+}
+
 async function askAI(type) {
   const requestId = generateQARequestId();
   const questionForLog = type === 'custom'
@@ -3113,8 +3173,8 @@ async function askAI(type) {
     return;
   }
 
-  // 選択テキストがあれば、それを対象にする
-  const selection = window.getSelection().toString().trim();
+  // 本文領域の選択テキストがあれば、それを対象にする
+  const selection = getAllowedAISelectionText();
   const targetText = selection || transcript;
 
   // 入力サイズ制限（コスト暴発・フリーズ防止）
@@ -3219,6 +3279,7 @@ async function askAI(type) {
   } else {
     const responseEl = document.getElementById(`response-${type}`);
     responseEl.textContent = '';
+    responseEl.removeAttribute('data-selection-content');
     const loading = document.createElement('span');
     loading.className = 'loading';
     responseEl.appendChild(loading);
@@ -3253,7 +3314,9 @@ async function askAI(type) {
       scheduleActiveMeetingDraftSave();
     } else if (type === 'minutes') {
       // 議事録は上書き（単一）
-      document.getElementById(`response-${type}`).textContent = response;
+      const responseEl = document.getElementById(`response-${type}`);
+      responseEl.textContent = response;
+      responseEl.setAttribute('data-selection-content', 'true');
       AppState.aiResponses.minutes = response;
       hideEmptyState('minutes'); // PR-3: エンプティステート非表示
       scheduleActiveMeetingDraftSave();
@@ -3266,7 +3329,9 @@ async function askAI(type) {
       const displayText = AppState.aiResponses[type].map((entry, i) => {
         return `━━━ #${i + 1}（${entry.timestamp}）━━━\n\n${entry.content}`;
       }).join('\n\n');
-      document.getElementById(`response-${type}`).textContent = displayText;
+      const responseEl = document.getElementById(`response-${type}`);
+      responseEl.textContent = displayText;
+      responseEl.setAttribute('data-selection-content', 'true');
       hideEmptyState(type); // PR-3: エンプティステート非表示
       scheduleActiveMeetingDraftSave();
     }
@@ -3317,6 +3382,7 @@ async function askAI(type) {
       // XSS防止: innerHTMLではなくcreateElement/textContentを使用
       const responseEl = document.getElementById(`response-${type}`);
       responseEl.textContent = '';
+      responseEl.removeAttribute('data-selection-content');
       const errSpan = document.createElement('span');
       errSpan.className = 'error-text';
       errSpan.textContent = errorMsg;
@@ -4067,7 +4133,7 @@ function createMemo(content) {
 }
 
 function getSelectedTranscriptQuote() {
-  const selection = window.getSelection().toString().trim();
+  const selection = getAllowedTranscriptSelectionText();
   if (!selection || selection.length < 5) return null;
 
   // 選択テキストにマッチするchunkを探す
@@ -5465,6 +5531,7 @@ function renderAIResponsesFromState() {
     if (!el) return;
 
     if (!AppState.aiResponses[type] || AppState.aiResponses[type].length === 0) {
+      el.removeAttribute('data-selection-content');
       el.textContent = t('app.aiResponse.placeholder');
       return;
     }
@@ -5474,6 +5541,7 @@ function renderAIResponsesFromState() {
       return `━━━ #${i + 1}${ts ? `（${ts}）` : ''} ━━━\n\n${entry.content}`;
     }).join('\n\n');
     el.textContent = displayText; // XSS安全
+    el.setAttribute('data-selection-content', 'true');
   });
 
   // タイムラインも更新
@@ -5482,7 +5550,13 @@ function renderAIResponsesFromState() {
   // minutes: textContentのみ
   const minutesEl = document.getElementById('response-minutes');
   if (minutesEl) {
-    minutesEl.textContent = AppState.aiResponses.minutes || t('app.aiResponse.minutesPlaceholder');
+    if (AppState.aiResponses.minutes) {
+      minutesEl.textContent = AppState.aiResponses.minutes;
+      minutesEl.setAttribute('data-selection-content', 'true');
+    } else {
+      minutesEl.removeAttribute('data-selection-content');
+      minutesEl.textContent = t('app.aiResponse.minutesPlaceholder');
+    }
   }
 
   // custom Q&A: DOM生成でtextContent使用

--- a/js/lib/selection-utils.js
+++ b/js/lib/selection-utils.js
@@ -1,0 +1,90 @@
+// =====================================
+// Selection Utilities
+// =====================================
+// Restricts window selections to intentional content areas.
+
+const SelectionUtils = (function() {
+  'use strict';
+
+  function toElement(node) {
+    if (!node) return null;
+    if (node.nodeType === 1) return node;
+    return node.parentElement || null;
+  }
+
+  function matchesAny(element, selectors) {
+    if (!element || !selectors || selectors.length === 0) return false;
+    if (typeof element.matches !== 'function') return false;
+    return selectors.some(function(selector) {
+      try {
+        return element.matches(selector);
+      } catch (_) {
+        return false;
+      }
+    });
+  }
+
+  function closestAny(element, selectors) {
+    if (!element || !selectors || selectors.length === 0) return null;
+    if (typeof element.closest !== 'function') return null;
+    for (var i = 0; i < selectors.length; i++) {
+      try {
+        var match = element.closest(selectors[i]);
+        if (match) return match;
+      } catch (_) {
+        // Ignore invalid selectors supplied by callers.
+      }
+    }
+    return null;
+  }
+
+  function isElementAllowedForSelection(element, allowedSelectors, blockedSelectors) {
+    if (!element) return false;
+    if (closestAny(element, blockedSelectors)) return false;
+    return Boolean(closestAny(element, allowedSelectors));
+  }
+
+  function getTextControlSelection(activeElement, allowedSelectors) {
+    if (!activeElement || !matchesAny(activeElement, allowedSelectors)) return '';
+    if (typeof activeElement.value !== 'string') return '';
+    if (typeof activeElement.selectionStart !== 'number' || typeof activeElement.selectionEnd !== 'number') return '';
+    if (activeElement.selectionStart === activeElement.selectionEnd) return '';
+
+    var start = Math.min(activeElement.selectionStart, activeElement.selectionEnd);
+    var end = Math.max(activeElement.selectionStart, activeElement.selectionEnd);
+    return activeElement.value.slice(start, end).trim();
+  }
+
+  function getAllowedSelectionText(options) {
+    var opts = options || {};
+    var allowedSelectors = opts.allowedSelectors || [];
+    var blockedSelectors = opts.blockedSelectors || [];
+    var doc = opts.documentRef || (typeof document !== 'undefined' ? document : null);
+    var selection = opts.selection || (typeof window !== 'undefined' && typeof window.getSelection === 'function'
+      ? window.getSelection()
+      : null);
+
+    var textControlSelection = getTextControlSelection(doc && doc.activeElement, allowedSelectors);
+    if (textControlSelection) return textControlSelection;
+
+    if (!selection || !selection.rangeCount || typeof selection.toString !== 'function') return '';
+    var text = selection.toString().trim();
+    if (!text) return '';
+
+    var anchorEl = toElement(selection.anchorNode);
+    var focusEl = toElement(selection.focusNode);
+    if (!isElementAllowedForSelection(anchorEl, allowedSelectors, blockedSelectors)) return '';
+    if (!isElementAllowedForSelection(focusEl, allowedSelectors, blockedSelectors)) return '';
+
+    return text;
+  }
+
+  return {
+    getAllowedSelectionText: getAllowedSelectionText,
+    isElementAllowedForSelection: isElementAllowedForSelection
+  };
+})();
+
+if (typeof window !== 'undefined') {
+  window.SelectionUtils = SelectionUtils;
+}

--- a/tests/unit/selection-utils.test.mjs
+++ b/tests/unit/selection-utils.test.mjs
@@ -1,0 +1,209 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadScript } from '../helpers/load-script.mjs';
+
+const { SelectionUtils } = loadScript('js/lib/selection-utils.js', {
+  window: {}
+});
+
+function selectorListMatches(selectorList, selector) {
+  return selectorList.split(',').map(s => s.trim()).includes(selector);
+}
+
+function createElement(selectors = [], parentElement = null) {
+  const element = {
+    nodeType: 1,
+    parentElement,
+    matches(selectorList) {
+      return selectors.some(selector => selectorListMatches(selectorList, selector));
+    },
+    closest(selectorList) {
+      let current = element;
+      while (current) {
+        if (current.matches(selectorList)) return current;
+        current = current.parentElement;
+      }
+      return null;
+    }
+  };
+  return element;
+}
+
+function createTextNode(parentElement) {
+  return {
+    nodeType: 3,
+    parentElement
+  };
+}
+
+function createSelection(text, anchorNode, focusNode) {
+  return {
+    rangeCount: 1,
+    anchorNode,
+    focusNode,
+    toString() {
+      return text;
+    }
+  };
+}
+
+const AI_ALLOWED = [
+  '#transcriptText .transcript-chunk',
+  '#memoListInTab .timeline-item-content',
+  '.ai-response[data-selection-content="true"]',
+  '#contextGoalInput'
+];
+const TRANSCRIPT_ALLOWED = ['#transcriptText .transcript-chunk'];
+const BLOCKED = ['button', '.btn', '.tab'];
+
+describe('SelectionUtils.getAllowedSelectionText', () => {
+  it('returns selected text from allowed transcript content', () => {
+    const transcriptChunk = createElement(['#transcriptText .transcript-chunk']);
+    const textNode = createTextNode(transcriptChunk);
+    const selection = createSelection(' transcript text ', textNode, textNode);
+
+    assert.equal(
+      SelectionUtils.getAllowedSelectionText({
+        selection,
+        allowedSelectors: AI_ALLOWED,
+        blockedSelectors: BLOCKED
+      }),
+      'transcript text'
+    );
+  });
+
+  it('returns selected text from allowed memo content', () => {
+    const memoContent = createElement(['#memoListInTab .timeline-item-content']);
+    const textNode = createTextNode(memoContent);
+    const selection = createSelection('memo text', textNode, textNode);
+
+    assert.equal(
+      SelectionUtils.getAllowedSelectionText({
+        selection,
+        allowedSelectors: AI_ALLOWED,
+        blockedSelectors: BLOCKED
+      }),
+      'memo text'
+    );
+  });
+
+  it('ignores selected UI text outside allowed content areas', () => {
+    const tab = createElement(['.tab']);
+    const textNode = createTextNode(tab);
+    const selection = createSelection('AI回答', textNode, textNode);
+
+    assert.equal(
+      SelectionUtils.getAllowedSelectionText({
+        selection,
+        allowedSelectors: AI_ALLOWED,
+        blockedSelectors: BLOCKED
+      }),
+      ''
+    );
+  });
+
+  it('returns selected text from marked AI response content', () => {
+    const aiResponse = createElement(['.ai-response[data-selection-content="true"]']);
+    const textNode = createTextNode(aiResponse);
+    const selection = createSelection('AI answer text', textNode, textNode);
+
+    assert.equal(
+      SelectionUtils.getAllowedSelectionText({
+        selection,
+        allowedSelectors: AI_ALLOWED,
+        blockedSelectors: BLOCKED
+      }),
+      'AI answer text'
+    );
+  });
+
+  it('ignores unmarked AI response placeholder text', () => {
+    const placeholder = createElement(['.ai-response']);
+    const textNode = createTextNode(placeholder);
+    const selection = createSelection('No AI response yet', textNode, textNode);
+
+    assert.equal(
+      SelectionUtils.getAllowedSelectionText({
+        selection,
+        allowedSelectors: AI_ALLOWED,
+        blockedSelectors: BLOCKED
+      }),
+      ''
+    );
+  });
+
+  it('ignores blocked controls even inside an allowed container', () => {
+    const transcriptChunk = createElement(['#transcriptText .transcript-chunk']);
+    const button = createElement(['button'], transcriptChunk);
+    const textNode = createTextNode(button);
+    const selection = createSelection('copy', textNode, textNode);
+
+    assert.equal(
+      SelectionUtils.getAllowedSelectionText({
+        selection,
+        allowedSelectors: AI_ALLOWED,
+        blockedSelectors: BLOCKED
+      }),
+      ''
+    );
+  });
+
+  it('ignores selections that cross from content into UI', () => {
+    const transcriptChunk = createElement(['#transcriptText .transcript-chunk']);
+    const tab = createElement(['.tab']);
+    const selection = createSelection(
+      'transcript plus tab',
+      createTextNode(transcriptChunk),
+      createTextNode(tab)
+    );
+
+    assert.equal(
+      SelectionUtils.getAllowedSelectionText({
+        selection,
+        allowedSelectors: AI_ALLOWED,
+        blockedSelectors: BLOCKED
+      }),
+      ''
+    );
+  });
+
+  it('can restrict callers to transcript-only selections', () => {
+    const memoContent = createElement(['#memoListInTab .timeline-item-content']);
+    const textNode = createTextNode(memoContent);
+    const selection = createSelection('memo text', textNode, textNode);
+
+    assert.equal(
+      SelectionUtils.getAllowedSelectionText({
+        selection,
+        allowedSelectors: TRANSCRIPT_ALLOWED,
+        blockedSelectors: BLOCKED
+      }),
+      ''
+    );
+  });
+
+  it('returns selected text from allowed text controls', () => {
+    const contextInput = {
+      nodeType: 1,
+      value: 'agenda and background',
+      selectionStart: 0,
+      selectionEnd: 6,
+      matches(selectorList) {
+        return selectorListMatches(selectorList, '#contextGoalInput');
+      },
+      closest() {
+        return null;
+      }
+    };
+
+    assert.equal(
+      SelectionUtils.getAllowedSelectionText({
+        documentRef: { activeElement: contextInput },
+        selection: null,
+        allowedSelectors: AI_ALLOWED,
+        blockedSelectors: BLOCKED
+      }),
+      'agenda'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add `SelectionUtils` to restrict selected text to intentional content areas.
- Use scoped selection in `askAI` so UI labels, buttons, tabs, status text, toast text, and other chrome are ignored.
- Keep fallback behavior: disallowed or empty selections fall back to the normal transcript context.
- Restrict memo quote selection to transcript content only.
- Mark actual AI responses as selectable while leaving placeholders, loading text, and error text unselectable.

## Allowed Selection Areas
- Transcript chunks
- Memo and timeline content / quotes
- Marked AI response content and Q&A entries
- Meeting context text inputs

## Scope
- PR-6C only: `askAI` / related selection retrieval.
- No UI refresh.
- No `app.js` split.
- No recording pipeline changes.
- No `fetchWithRetry`, Gemini auth, queue persistence, or API-key storage changes.

## Verification
- `node --test tests/unit/selection-utils.test.mjs` passed.
- `npm run test:unit` passed: 203 tests.
- `npm run lint` passed with 1 existing warning (`SecureStorage` public global).
- `npm run test:ui-smoke` passed.
- `git diff --check` passed.

## Notes
- `npm ci` reported 3 audit findings (1 moderate, 2 high); not addressed because dependency remediation is outside PR-6C scope.