### PR TITLE
refactor: extract history backup service

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,6 +42,7 @@ export default [
         TranscriptionQueueOverflowService: 'readonly',
         FetchRetryService: 'readonly',
         ExportService: 'readonly',
+        HistoryBackupService: 'readonly',
         DiagnosticsService: 'readonly',
         STTProviders: 'writable',
         PCMStreamProcessor: 'writable',

--- a/index.html
+++ b/index.html
@@ -738,6 +738,7 @@
   <script src="js/services/transcription-queue-overflow-service.js" defer></script>
   <script src="js/services/fetch-retry-service.js" defer></script>
   <script src="js/services/export-service.js" defer></script>
+  <script src="js/services/history-backup-service.js" defer></script>
   <script src="js/services/diagnostics-service.js" defer></script>
   <!-- メインアプリ -->
   <script src="js/app.js" defer></script>

--- a/js/app.js
+++ b/js/app.js
@@ -306,6 +306,7 @@ var llmClientService = (typeof LLMClientService !== 'undefined') ? LLMClientServ
 var meetingContextService = (typeof MeetingContextService !== 'undefined') ? MeetingContextService : null;
 var activeMeetingDraftService = (typeof window !== 'undefined' && window.ActiveMeetingDraftService) ? window.ActiveMeetingDraftService : null;
 var exportService = (typeof ExportService !== 'undefined') ? ExportService : null;
+var historyBackupService = (typeof HistoryBackupService !== 'undefined') ? HistoryBackupService : null;
 var diagnosticsService = (typeof DiagnosticsService !== 'undefined') ? DiagnosticsService : null;
 
 // Handle fatal errors - show modal and safely stop recording
@@ -6016,48 +6017,22 @@ async function clearHistoryRecords() {
   await renderHistoryList();
 }
 
-function normalizeHistoryBackupRecord(record, index) {
-  const nowIso = new Date().toISOString();
-  const normalized = deepCopy(record || {});
-  if (!normalized.id || typeof normalized.id !== 'string') {
-    normalized.id = `history_import_${Date.now()}_${index}_${Math.random().toString(36).slice(2, 8)}`;
-  }
-  if (!normalized.createdAt || Number.isNaN(new Date(normalized.createdAt).getTime())) {
-    normalized.createdAt = nowIso;
-  }
-  if (!normalized.updatedAt || Number.isNaN(new Date(normalized.updatedAt).getTime())) {
-    normalized.updatedAt = nowIso;
-  }
-  return normalized;
-}
-
 function parseHistoryBackupRecords(rawJson) {
-  let parsed;
-  try {
-    parsed = JSON.parse(rawJson);
-  } catch (err) {
+  if (!historyBackupService) {
     throw new Error(t('history.backupInvalidFormat'));
   }
-
-  const records = Array.isArray(parsed)
-    ? parsed
-    : (Array.isArray(parsed?.records) ? parsed.records : null);
-
-  if (!records) {
-    throw new Error(t('history.backupInvalidFormat'));
-  }
-
-  const normalizedRecords = records
-    .filter(record => record && typeof record === 'object')
-    .map((record, index) => normalizeHistoryBackupRecord(record, index))
-    .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
-
-  return normalizedRecords;
+  return historyBackupService.parseRecords(rawJson, {
+    invalidFormatMessage: t('history.backupInvalidFormat')
+  });
 }
 
 async function downloadHistoryBackup() {
   if (typeof HistoryStore === 'undefined') {
     showToast(t('history.notSupported'), 'error');
+    return false;
+  }
+  if (!historyBackupService) {
+    showToast(t('history.backupInvalidFormat'), 'error');
     return false;
   }
 
@@ -6067,13 +6042,7 @@ async function downloadHistoryBackup() {
     return false;
   }
 
-  const payload = {
-    schemaVersion: 1,
-    exportedAt: new Date().toISOString(),
-    app: 'ai-meeting-assistant',
-    recordCount: records.length,
-    records: records.map(record => deepCopy(record))
-  };
+  const payload = historyBackupService.buildBackupPayload(records);
 
   const fileName = `meeting-history-backup-${new Date().toISOString().split('T')[0]}.json`;
   return downloadJsonFile(JSON.stringify(payload, null, 2), fileName, 'history.backupDownloadSuccess');

--- a/js/services/history-backup-service.js
+++ b/js/services/history-backup-service.js
@@ -1,0 +1,75 @@
+const HistoryBackupService = (function() {
+  'use strict';
+
+  const DEFAULT_INVALID_FORMAT_MESSAGE = 'Invalid history backup format';
+
+  function deepCopy(value) {
+    if (value === undefined) return undefined;
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function createImportedRecordId(index) {
+    return `history_import_${Date.now()}_${index}_${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  function normalizeRecord(record, index, options = {}) {
+    const nowIso = options.nowIso || new Date().toISOString();
+    const normalized = deepCopy(record || {});
+
+    if (!normalized.id || typeof normalized.id !== 'string') {
+      const createId = typeof options.createId === 'function' ? options.createId : createImportedRecordId;
+      normalized.id = createId(index);
+    }
+    if (!normalized.createdAt || Number.isNaN(new Date(normalized.createdAt).getTime())) {
+      normalized.createdAt = nowIso;
+    }
+    if (!normalized.updatedAt || Number.isNaN(new Date(normalized.updatedAt).getTime())) {
+      normalized.updatedAt = nowIso;
+    }
+    return normalized;
+  }
+
+  function parseRecords(rawJson, options = {}) {
+    const invalidFormatMessage = options.invalidFormatMessage || DEFAULT_INVALID_FORMAT_MESSAGE;
+    let parsed;
+    try {
+      parsed = JSON.parse(rawJson);
+    } catch (err) {
+      throw new Error(invalidFormatMessage);
+    }
+
+    const records = Array.isArray(parsed)
+      ? parsed
+      : (Array.isArray(parsed?.records) ? parsed.records : null);
+
+    if (!records) {
+      throw new Error(invalidFormatMessage);
+    }
+
+    return records
+      .filter(record => record && typeof record === 'object')
+      .map((record, index) => normalizeRecord(record, index, options))
+      .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+  }
+
+  function buildBackupPayload(records, options = {}) {
+    const sourceRecords = Array.isArray(records) ? records : [];
+    return {
+      schemaVersion: 1,
+      exportedAt: options.exportedAt || new Date().toISOString(),
+      app: 'ai-meeting-assistant',
+      recordCount: sourceRecords.length,
+      records: sourceRecords.map(record => deepCopy(record))
+    };
+  }
+
+  return {
+    normalizeRecord,
+    parseRecords,
+    buildBackupPayload
+  };
+})();
+
+if (typeof window !== 'undefined') {
+  window.HistoryBackupService = HistoryBackupService;
+}

--- a/tests/unit/history-backup-service.test.mjs
+++ b/tests/unit/history-backup-service.test.mjs
@@ -1,0 +1,83 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadScript } from '../helpers/load-script.mjs';
+
+const { HistoryBackupService } = loadScript('js/services/history-backup-service.js', {
+  window: {}
+});
+
+describe('HistoryBackupService.parseRecords', () => {
+  it('parses array backup files and sorts records by createdAt ascending', () => {
+    const records = HistoryBackupService.parseRecords(JSON.stringify([
+      { id: 'newer', createdAt: '2026-06-14T10:00:00.000Z', updatedAt: '2026-06-14T10:00:00.000Z' },
+      { id: 'older', createdAt: '2026-06-13T10:00:00.000Z', updatedAt: '2026-06-13T10:00:00.000Z' }
+    ]));
+
+    assert.deepEqual(Array.from(records, record => record.id), ['older', 'newer']);
+  });
+
+  it('parses wrapped backup files with a records array', () => {
+    const records = HistoryBackupService.parseRecords(JSON.stringify({
+      schemaVersion: 1,
+      records: [
+        { id: 'history_1', createdAt: '2026-06-14T10:00:00.000Z', updatedAt: '2026-06-14T10:00:00.000Z' }
+      ]
+    }));
+
+    assert.equal(records.length, 1);
+    assert.equal(records[0].id, 'history_1');
+  });
+
+  it('normalizes missing id and invalid timestamps without changing valid fields', () => {
+    const records = HistoryBackupService.parseRecords(JSON.stringify([
+      { title: 'Imported', createdAt: 'bad-date', updatedAt: '' }
+    ]), {
+      nowIso: '2026-06-14T12:00:00.000Z',
+      createId: index => `test_id_${index}`
+    });
+
+    assert.equal(records[0].id, 'test_id_0');
+    assert.equal(records[0].title, 'Imported');
+    assert.equal(records[0].createdAt, '2026-06-14T12:00:00.000Z');
+    assert.equal(records[0].updatedAt, '2026-06-14T12:00:00.000Z');
+  });
+
+  it('filters non-object entries', () => {
+    const records = HistoryBackupService.parseRecords(JSON.stringify([
+      null,
+      'bad',
+      { id: 'valid', createdAt: '2026-06-14T10:00:00.000Z', updatedAt: '2026-06-14T10:00:00.000Z' }
+    ]));
+
+    assert.equal(records.length, 1);
+    assert.equal(records[0].id, 'valid');
+  });
+
+  it('throws caller supplied invalid format messages', () => {
+    assert.throws(
+      () => HistoryBackupService.parseRecords('{', { invalidFormatMessage: 'localized invalid' }),
+      /localized invalid/
+    );
+    assert.throws(
+      () => HistoryBackupService.parseRecords('{"notRecords":[]}', { invalidFormatMessage: 'localized invalid' }),
+      /localized invalid/
+    );
+  });
+});
+
+describe('HistoryBackupService.buildBackupPayload', () => {
+  it('builds the existing backup envelope and deep copies records', () => {
+    const source = [{ id: 'history_1', nested: { value: 'original' } }];
+    const payload = HistoryBackupService.buildBackupPayload(source, {
+      exportedAt: '2026-06-14T12:34:00.000Z'
+    });
+
+    source[0].nested.value = 'changed';
+
+    assert.equal(payload.schemaVersion, 1);
+    assert.equal(payload.exportedAt, '2026-06-14T12:34:00.000Z');
+    assert.equal(payload.app, 'ai-meeting-assistant');
+    assert.equal(payload.recordCount, 1);
+    assert.equal(payload.records[0].nested.value, 'original');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `HistoryBackupService` for history backup JSON parsing, imported-record normalization, and backup payload construction.
- Delegate the existing history backup import/export helpers in `app.js` to the service.
- Add unit coverage for array backups, wrapped `{ records }` backups, missing IDs/timestamps, invalid format errors, sorting, and deep-copy backup payloads.

## P1-1 Scope
- Investigated storage/history/draft extraction candidates.
- Kept this first P1 PR to the smallest low-risk unit: history backup JSON helpers.
- Did not touch IndexedDB schema, saved record format, active draft runtime timers, restore UI, or history list UI.

## Extraction Candidates Considered
- Active draft runtime orchestration: deferred because it touches save timers, AppState, and DOM restore flow.
- History record builder: deferred because it depends on export markdown generation and broader AppState shape.
- History backup JSON helpers: selected because the logic is pure and already isolated from IndexedDB/UI behavior.

## Verification
- `node --test tests/unit/history-backup-service.test.mjs` passed.
- `npm run test:unit` passed: 209 tests.
- `npm run lint` passed with 1 existing warning (`SecureStorage` public global).
- `npm run test:ui-smoke` passed.
- `git diff --check` passed.

## Notes
- No storage schema change.
- No saved data format change.
- No UI behavior change.
- No app-wide split, ESM conversion, TypeScript conversion, queue persistence, or API-key storage change.