### PR TITLE
refactor: extract history import record check

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -6054,7 +6054,7 @@ async function importHistoryBackupFromFile(file) {
   try {
     const raw = await file.text();
     const records = parseHistoryBackupRecords(raw);
-    if (!records.length) {
+    if (!historyBackupService.hasImportableRecords(records)) {
       showToast(t('history.backupImportNoRecords'), 'warning');
       return false;
     }

--- a/js/services/history-backup-service.js
+++ b/js/services/history-backup-service.js
@@ -63,10 +63,15 @@ const HistoryBackupService = (function() {
     };
   }
 
+  function hasImportableRecords(records) {
+    return Array.isArray(records) && records.length > 0;
+  }
+
   return {
     normalizeRecord,
     parseRecords,
-    buildBackupPayload
+    buildBackupPayload,
+    hasImportableRecords
   };
 })();
 

--- a/tests/unit/history-backup-service.test.mjs
+++ b/tests/unit/history-backup-service.test.mjs
@@ -81,3 +81,12 @@ describe('HistoryBackupService.buildBackupPayload', () => {
     assert.equal(payload.records[0].nested.value, 'original');
   });
 });
+
+describe('HistoryBackupService.hasImportableRecords', () => {
+  it('returns true only for non-empty record arrays', () => {
+    assert.equal(HistoryBackupService.hasImportableRecords([{ id: 'history_1' }]), true);
+    assert.equal(HistoryBackupService.hasImportableRecords([]), false);
+    assert.equal(HistoryBackupService.hasImportableRecords(null), false);
+    assert.equal(HistoryBackupService.hasImportableRecords({ records: [{ id: 'history_1' }] }), false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `HistoryBackupService.hasImportableRecords()` for the history backup import empty-record check.
- Replace the direct `records.length` check in `importHistoryBackupFromFile()` with the service helper.
- Extend `history-backup-service` unit tests for importable record detection.

## P1-2 Scope
- Investigated the history backup import flow in `app.js`.
- Selected the smallest pure validation unit: whether parsed records contain anything importable.
- Left import flow, toast copy/timing, confirm prompts, DOM updates, IndexedDB writes, and storage schema unchanged.

## Extraction Candidates Considered
- Import mode confirm / overwrite decision: deferred because it is UI prompt flow.
- Save loop / imported count handling: deferred because it directly touches IndexedDB writes.
- Empty importable records check: selected because it is pure and already follows `parseRecords()`.

## Verification
- `node --test tests/unit/history-backup-service.test.mjs` passed.
- `npm run test:unit` passed: 210 tests.
- `npm run lint` passed with 1 existing warning (`SecureStorage` public global).
- `npm run test:ui-smoke` passed.
- `git diff --check` passed.

## Notes
- No IndexedDB schema change.
- No saved data format change.
- No history UI or restore UI change.
- No toast text or timing change.
- No active draft runtime changes.