### PR TITLE
refactor: extract history backup file name

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -6044,7 +6044,7 @@ async function downloadHistoryBackup() {
 
   const payload = historyBackupService.buildBackupPayload(records);
 
-  const fileName = `meeting-history-backup-${new Date().toISOString().split('T')[0]}.json`;
+  const fileName = historyBackupService.buildBackupFileName();
   return downloadJsonFile(JSON.stringify(payload, null, 2), fileName, 'history.backupDownloadSuccess');
 }
 

--- a/js/services/history-backup-service.js
+++ b/js/services/history-backup-service.js
@@ -67,11 +67,16 @@ const HistoryBackupService = (function() {
     return Array.isArray(records) && records.length > 0;
   }
 
+  function buildBackupFileName(date = new Date()) {
+    return `meeting-history-backup-${date.toISOString().split('T')[0]}.json`;
+  }
+
   return {
     normalizeRecord,
     parseRecords,
     buildBackupPayload,
-    hasImportableRecords
+    hasImportableRecords,
+    buildBackupFileName
   };
 })();
 

--- a/tests/unit/history-backup-service.test.mjs
+++ b/tests/unit/history-backup-service.test.mjs
@@ -90,3 +90,11 @@ describe('HistoryBackupService.hasImportableRecords', () => {
     assert.equal(HistoryBackupService.hasImportableRecords({ records: [{ id: 'history_1' }] }), false);
   });
 });
+
+describe('HistoryBackupService.buildBackupFileName', () => {
+  it('preserves the existing history backup file name format', () => {
+    const fileName = HistoryBackupService.buildBackupFileName(new Date('2026-06-14T23:59:59.000Z'));
+
+    assert.equal(fileName, 'meeting-history-backup-2026-06-14.json');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `HistoryBackupService.buildBackupFileName()` for history backup export file naming.
- Replace the inline file name template in `downloadHistoryBackup()` with the service helper.
- Add a unit test to preserve the existing `meeting-history-backup-YYYY-MM-DD.json` format.

## Investigated Candidates
1. Backup file name generation.
2. Backup JSON stringify wrapper.
3. Import parse + empty check wrapper.

## Selected Candidate
- Selected backup file name generation because it is pure, DOM-free, toast-free, IndexedDB-free, and easy to test without touching import/save behavior.

## Deferred Candidates
- Backup JSON stringify wrapper: deferred to avoid bundling multiple export wrapper changes in one PR.
- Import parse + empty check wrapper: deferred because P1-2 already moved the smallest import check and a broader wrapper would touch more of the import flow.

## Verification
- `node --test tests/unit/history-backup-service.test.mjs` passed.
- `npm run test:unit` passed: 211 tests.
- `npm run lint` passed with 1 existing warning (`SecureStorage` public global).
- `npm run test:ui-smoke` passed.
- `git diff --check` passed.

## Notes
- Exported JSON structure is unchanged.
- Exported file name format is covered by test and remains `meeting-history-backup-YYYY-MM-DD.json`.
- No IndexedDB schema change.
- No history UI or restore UI change.
- No toast text or timing change.
- No active draft runtime changes.