### PR TITLE
refactor: extract history list display preparation

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,6 +43,7 @@ export default [
         FetchRetryService: 'readonly',
         ExportService: 'readonly',
         HistoryBackupService: 'readonly',
+        HistoryListService: 'readonly',
         DiagnosticsService: 'readonly',
         STTProviders: 'writable',
         PCMStreamProcessor: 'writable',

--- a/index.html
+++ b/index.html
@@ -739,6 +739,7 @@
   <script src="js/services/fetch-retry-service.js" defer></script>
   <script src="js/services/export-service.js" defer></script>
   <script src="js/services/history-backup-service.js" defer></script>
+  <script src="js/services/history-list-service.js" defer></script>
   <script src="js/services/diagnostics-service.js" defer></script>
   <!-- メインアプリ -->
   <script src="js/app.js" defer></script>

--- a/js/app.js
+++ b/js/app.js
@@ -307,6 +307,7 @@ var meetingContextService = (typeof MeetingContextService !== 'undefined') ? Mee
 var activeMeetingDraftService = (typeof window !== 'undefined' && window.ActiveMeetingDraftService) ? window.ActiveMeetingDraftService : null;
 var exportService = (typeof ExportService !== 'undefined') ? ExportService : null;
 var historyBackupService = (typeof HistoryBackupService !== 'undefined') ? HistoryBackupService : null;
+var historyListService = (typeof HistoryListService !== 'undefined') ? HistoryListService : null;
 var diagnosticsService = (typeof DiagnosticsService !== 'undefined') ? DiagnosticsService : null;
 
 // Handle fatal errors - show modal and safely stop recording
@@ -5907,6 +5908,12 @@ async function renderHistoryList() {
   }
 
   records.forEach(record => {
+    const display = historyListService.prepareDisplayRecord(record, {
+      getDefaultTitle: getDefaultMeetingTitle,
+      formatTimestamp: formatHistoryTimestamp,
+      truncatePreview: truncateText
+    });
+
     const item = document.createElement('div');
     item.className = 'history-item';
     item.style.border = '1px solid var(--border)';
@@ -5923,21 +5930,21 @@ async function renderHistoryList() {
     const title = document.createElement('div');
     title.style.fontWeight = '600';
     title.style.marginBottom = '0.25rem';
-    title.textContent = record.title || getDefaultMeetingTitle(record.createdAt ? new Date(record.createdAt) : undefined);
+    title.textContent = display.title;
     meta.appendChild(title);
 
     const details = document.createElement('div');
     details.style.fontSize = '0.85rem';
     details.style.color = 'var(--text-secondary)';
-    details.textContent = `${t('history.recordSavedAt')} ${formatHistoryTimestamp(record.createdAt)} ・ ${t('history.recordDuration')} ${formatHistoryDuration(record.durationSec)}`;
+    details.textContent = `${t('history.recordSavedAt')} ${display.savedAt} ・ ${t('history.recordDuration')} ${display.duration}`;
     meta.appendChild(details);
 
-    if (record.summaryPreview) {
+    if (display.hasSummaryPreview) {
       const preview = document.createElement('p');
       preview.style.fontSize = '0.9rem';
       preview.style.marginTop = '0.5rem';
       preview.style.whiteSpace = 'pre-line';
-      preview.textContent = truncateText(record.summaryPreview);
+      preview.textContent = display.summaryPreview;
       meta.appendChild(preview);
     }
 
@@ -6347,12 +6354,6 @@ function formatHistoryTimestamp(isoString) {
   const date = new Date(isoString);
   const locale = I18n.getLanguage() === 'ja' ? 'ja-JP' : 'en-US';
   return date.toLocaleString(locale, { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' });
-}
-
-function formatHistoryDuration(seconds) {
-  if (!seconds || Number.isNaN(seconds)) return '0m';
-  const mins = Math.max(1, Math.round(seconds / 60));
-  return `${mins}m`;
 }
 
 // =====================================

--- a/js/services/history-list-service.js
+++ b/js/services/history-list-service.js
@@ -1,0 +1,43 @@
+const HistoryListService = (function() {
+  'use strict';
+
+  function formatDuration(seconds) {
+    if (!seconds || Number.isNaN(seconds)) return '0m';
+    const mins = Math.max(1, Math.round(seconds / 60));
+    return `${mins}m`;
+  }
+
+  function prepareDisplayRecord(record, options = {}) {
+    const source = record || {};
+    const getDefaultTitle = typeof options.getDefaultTitle === 'function'
+      ? options.getDefaultTitle
+      : function() { return ''; };
+    const formatTimestamp = typeof options.formatTimestamp === 'function'
+      ? options.formatTimestamp
+      : function() { return ''; };
+    const truncatePreview = typeof options.truncatePreview === 'function'
+      ? options.truncatePreview
+      : function(value) { return value || ''; };
+
+    const titleDate = source.createdAt ? new Date(source.createdAt) : undefined;
+    const hasSummaryPreview = Boolean(source.summaryPreview);
+
+    return {
+      id: source.id || '',
+      title: source.title || getDefaultTitle(titleDate),
+      savedAt: formatTimestamp(source.createdAt),
+      duration: formatDuration(source.durationSec),
+      hasSummaryPreview,
+      summaryPreview: hasSummaryPreview ? truncatePreview(source.summaryPreview) : ''
+    };
+  }
+
+  return {
+    formatDuration,
+    prepareDisplayRecord
+  };
+})();
+
+if (typeof window !== 'undefined') {
+  window.HistoryListService = HistoryListService;
+}

--- a/tests/unit/history-list-service.test.mjs
+++ b/tests/unit/history-list-service.test.mjs
@@ -1,0 +1,69 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadScript } from '../helpers/load-script.mjs';
+
+const { HistoryListService } = loadScript('js/services/history-list-service.js', {
+  window: {}
+});
+
+describe('HistoryListService.formatDuration', () => {
+  it('keeps the existing minute display behavior', () => {
+    assert.equal(HistoryListService.formatDuration(0), '0m');
+    assert.equal(HistoryListService.formatDuration(null), '0m');
+    assert.equal(HistoryListService.formatDuration(Number.NaN), '0m');
+    assert.equal(HistoryListService.formatDuration(1), '1m');
+    assert.equal(HistoryListService.formatDuration(89), '1m');
+    assert.equal(HistoryListService.formatDuration(90), '2m');
+  });
+});
+
+describe('HistoryListService.prepareDisplayRecord', () => {
+  it('prepares display metadata without changing existing record values', () => {
+    const display = HistoryListService.prepareDisplayRecord({
+      id: 'history_1',
+      title: 'Planning',
+      createdAt: '2026-06-14T09:00:00.000Z',
+      durationSec: 125,
+      summaryPreview: 'summary text'
+    }, {
+      getDefaultTitle: () => 'Default title',
+      formatTimestamp: value => `saved:${value}`,
+      truncatePreview: value => `trimmed:${value}`
+    });
+
+    assert.equal(display.id, 'history_1');
+    assert.equal(display.title, 'Planning');
+    assert.equal(display.savedAt, 'saved:2026-06-14T09:00:00.000Z');
+    assert.equal(display.duration, '2m');
+    assert.equal(display.hasSummaryPreview, true);
+    assert.equal(display.summaryPreview, 'trimmed:summary text');
+  });
+
+  it('uses the same fallback title date shape as renderHistoryList', () => {
+    let fallbackDate;
+    const display = HistoryListService.prepareDisplayRecord({
+      createdAt: '2026-06-14T09:00:00.000Z',
+      durationSec: 0
+    }, {
+      getDefaultTitle: date => {
+        fallbackDate = date;
+        return 'Default meeting';
+      }
+    });
+
+    assert.equal(display.title, 'Default meeting');
+    assert.equal(typeof fallbackDate.toISOString, 'function');
+    assert.equal(fallbackDate.toISOString(), '2026-06-14T09:00:00.000Z');
+  });
+
+  it('preserves summary preview presence separately from truncated text', () => {
+    const display = HistoryListService.prepareDisplayRecord({
+      summaryPreview: '   '
+    }, {
+      truncatePreview: () => ''
+    });
+
+    assert.equal(display.hasSummaryPreview, true);
+    assert.equal(display.summaryPreview, '');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `HistoryListService` for DOM-independent history list display metadata.
- Move duration formatting and per-record display preparation out of `renderHistoryList()`.
- Keep DOM structure, CSS, i18n keys, record order, storage format, and IndexedDB behavior unchanged.
- Add unit coverage for duration formatting, title fallback date handling, and summary preview preservation.

## Investigated Candidates
1. Per-record history list display metadata preparation.
2. Duration display helper only.
3. Records display-order normalization.

## Selected Candidate
- Selected per-record display metadata preparation because it removes a small DOM-independent responsibility from `renderHistoryList()` while preserving the existing DOM rendering flow.

## Deferred Candidates
- Duration helper only: deferred because it was too small to be useful by itself once display metadata preparation could include it safely.
- Records display-order normalization: deferred because record order is already provided by `HistoryStore.list()` and changing that boundary could look like a behavior change.

## Verification
- `node --test tests/unit/history-list-service.test.mjs` passed.
- `npm run test:unit` passed: 215 tests.
- `npm run lint` passed with 1 existing warning (`SecureStorage` public global).
- `npm run test:ui-smoke` passed.
- `git diff --check` passed.

## Notes
- No history list DOM structure change.
- No CSS change.
- No toast text or timing change.
- No IndexedDB schema change.
- No saved data format change.
- No active draft runtime or restore modal flow changes.
- No export markdown changes.