### PR TITLE
refactor: extract export markdown file name

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5095,9 +5095,9 @@ async function downloadExport() {
 
   const md = generateExportMarkdown(options);
   const title = getMeetingTitleValue();
-  const safeTitle = sanitizeFileName(title || 'meeting');
-  const dateStr = new Date().toISOString().split('T')[0];
-  const fileName = `${safeTitle}-${dateStr}.md`;
+  const fileName = exportService && typeof exportService.buildMarkdownFileName === 'function'
+    ? exportService.buildMarkdownFileName(title, { sanitizeFileName })
+    : `${sanitizeFileName(title || 'meeting')}-${new Date().toISOString().split('T')[0]}.md`;
   const completed = await downloadMarkdownFile(md, fileName, 'toast.export');
   if (completed) {
     closeExportModal();

--- a/js/services/export-service.js
+++ b/js/services/export-service.js
@@ -50,6 +50,17 @@ const ExportService = (function () {
     }).join('');
   }
 
+  function buildMarkdownFileName(title, options) {
+    const opts = options || {};
+    const sanitize = typeof opts.sanitizeFileName === 'function'
+      ? opts.sanitizeFileName
+      : function (value) { return value || 'meeting'; };
+    const date = opts.date || new Date();
+    const safeTitle = sanitize(title || 'meeting');
+    const dateStr = date.toISOString().split('T')[0];
+    return `${safeTitle}-${dateStr}.md`;
+  }
+
   function generateMarkdown(context) {
     const c = context || {};
     const t = typeof c.t === 'function' ? c.t : function (k) { return k; };
@@ -255,6 +266,7 @@ const ExportService = (function () {
   }
 
   return {
+    buildMarkdownFileName,
     collectAiWorkOrderInstructions,
     generateMarkdown
   };

--- a/tests/unit/export-service.test.mjs
+++ b/tests/unit/export-service.test.mjs
@@ -5,6 +5,24 @@ import { loadScript } from '../helpers/load-script.mjs';
 const { ExportService } = loadScript('js/services/export-service.js');
 
 describe('ExportService', () => {
+  it('builds the markdown export file name with the existing date format', () => {
+    const fileName = ExportService.buildMarkdownFileName('Weekly Sync', {
+      sanitizeFileName: (value) => value.replace(/\s+/g, '-'),
+      date: new Date('2026-06-14T23:59:59.000Z')
+    });
+
+    assert.equal(fileName, 'Weekly-Sync-2026-06-14.md');
+  });
+
+  it('uses the existing meeting fallback before sanitizing export file names', () => {
+    const fileName = ExportService.buildMarkdownFileName('', {
+      sanitizeFileName: (value) => `safe-${value}`,
+      date: new Date('2026-06-14T00:00:00.000Z')
+    });
+
+    assert.equal(fileName, 'safe-meeting-2026-06-14.md');
+  });
+
   it('extracts ai-work-order instructions from memo lines', () => {
     const result = ExportService.collectAiWorkOrderInstructions(
       [{ id: 'm1', timestamp: '10:00', content: 'AI: summarize blockers\nmemo line' }],


### PR DESCRIPTION
## Summary
- P1-5として export Markdown 周辺の純粋処理を調査
- 最小単位として Markdown export のファイル名生成だけを `ExportService.buildMarkdownFileName()` に抽出
- Markdown本文、見出し、セクション順序、download処理、toast文言・タイミングは変更なし

## 調査した候補
1. **export Markdown ファイル名生成の純粋関数化**
   - 採用。DOM / toast / download / Markdown本文に触れず、既存の `<safeTitle>-YYYY-MM-DD.md` をunit testで固定しやすいため。
2. **export options の選択有無判定のhelper化**
   - 見送り。低リスクだが効果が小さく、今回の export Markdown 周辺整理としてはファイル名生成の方が境界として明確なため。
3. **Markdown生成context / payload preparation の小抽出**
   - 見送り。`AppState`、i18n、format関数、本文生成に近く、出力仕様変更リスクが相対的に高いため。

## What Changed
- `ExportService.buildMarkdownFileName(title, options)` を追加
- `downloadExport()` のファイル名生成を同helperへ委譲
- `ExportService` が使えない場合の既存inline fallbackは維持
- 既存ファイル名形式と `meeting` fallback をunit testで固定

## Fixed Existing Behavior
- `Weekly Sync` + `2026-06-14` は `Weekly-Sync-2026-06-14.md`
- 空タイトルは従来どおり `meeting` fallback をsanitizeしてから `YYYY-MM-DD.md` を付与
- Markdown本文、見出し、順序、ファイル名仕様、download処理、toast文言・タイミングは変更なし

## Verification
- [x] `node --test tests/unit/export-service.test.mjs`
- [x] `npm run test:unit`
- [x] `npm run lint`（既存 warning 1件: `SecureStorage` no-unused-vars）
- [x] `npm run test:ui-smoke`
- [x] `git diff --check`

## Notes for Review
- このPRでは複数候補をまとめず、ファイル名生成の1点だけに限定しています。
- export Markdown本文生成、出力セクション、download処理、toast処理には触れていません。
