### PR TITLE
test: derive oversize fixture from app file-size limit (#147)

### DIFF
--- a/scripts/test-upload-edge.mjs
+++ b/scripts/test-upload-edge.mjs
@@ -14,7 +14,6 @@ import { ensureLocalStaticServer } from './local-static-server.mjs';
 
 const { results, record } = createResultTracker();
 const PORT = Number(process.env.PORT || 8080);
-const OVERSIZE_FILE_MB = 12;
 
 // ==========================
 // §6 Limit Control Tests
@@ -214,10 +213,16 @@ async function testEdgeCases(browser) {
         };
       });
 
+      // アプリ側の上限（CONTEXT_MAX_FILE_SIZE_MB）を実値で読み、+1MBで確実に超過させる
+      const limitMb = await page.evaluate(() =>
+        typeof CONTEXT_MAX_FILE_SIZE_MB === 'number' ? CONTEXT_MAX_FILE_SIZE_MB : 20
+      );
+      const oversizeMb = limitMb + 1;
+
       await page.setInputFiles('#contextFileInput', {
-        name: `test-${OVERSIZE_FILE_MB}mb.txt`,
+        name: `test-${oversizeMb}mb.txt`,
         mimeType: 'text/plain',
-        buffer: Buffer.alloc(OVERSIZE_FILE_MB * 1024 * 1024, 'A')
+        buffer: Buffer.alloc(oversizeMb * 1024 * 1024, 'A')
       });
 
       await page.waitForTimeout(2000);
@@ -234,10 +239,10 @@ async function testEdgeCases(browser) {
           charCount: bigFile.charCount || 0,
           warning: bigFile.errorMessage || ''
         };
-      }, `test-${OVERSIZE_FILE_MB}mb.txt`);
+      }, `test-${oversizeMb}mb.txt`);
 
       // Should be rejected (not added to files list)
-      record('§8', `test-${OVERSIZE_FILE_MB}mb.txt (size reject)`, 'success', {
+      record('§8', `test-${oversizeMb}mb.txt (size reject)`, 'success', {
         status: sizeResult.status === 'rejected' ? 'success' : 'fail',
         charCount: sizeResult.charCount,
         warning: sizeResult.warning


### PR DESCRIPTION
## 概要

`test-upload-edge` の size-reject テスト（issue #147 の既知の失敗）を修正します。

## 原因の説明（#147 受け入れ条件）

- テストは「12MBファイル → サイズ超過で拒否」を期待していたが、これは上限が2MBだった当時の前提。
- コミット 28e8da8 で `CONTEXT_MAX_FILE_SIZE_MB` が 2 → 20 に引き上げられたため、12MB は現仕様では**正しく受理**され、文字数制限(2000字)で TRUNCATED になる。アプリの動作は正常で、**stale なのはテストのフィクスチャ**。
- 修正は最小のレイヤー＝テスト側のみ。固定値ではなく、ページから実際の `CONTEXT_MAX_FILE_SIZE_MB` を読んで **+1MB** のフィクスチャを生成する方式にし、今後上限が変わってもテストが追従するようにした。

## 変更

- `scripts/test-upload-edge.mjs`: `OVERSIZE_FILE_MB = 12` 固定を廃止し、`page.evaluate` で実上限を取得して limit+1MB を生成（現状は 21MB → 拒否を確認）。

## 検証

- `npm run test:upload-edge` — 9 passed, 0 failed（従来 8 passed, 1 failed）
- `npm run test:upload-basic` — 6 passed / `test:upload-formats` — 7 passed
- `npm run test:unit` — fail 0
- `npm run lint` — 0 errors（既存 warning 1件のみ、本PRと無関係）
- `npm run test:ui-smoke` — pass
- `git diff --check` — clean

アプリコード・UIへの変更はありません。

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)