### PR TITLE
chore(lint): promote no-unused-vars to error as a dead-code guardrail

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -57,7 +57,7 @@ export default [
     },
     rules: {
       ...js.configs.recommended.rules,
-      'no-unused-vars': ['warn', { args: 'none', caughtErrors: 'none' }],
+      'no-unused-vars': ['error', { args: 'none', caughtErrors: 'none' }],
       // Each file re-declares the global it defines (e.g. const ModelRegistry = …)
       'no-redeclare': 'off',
       // Intentional control-char regex in file-extractor.js (mojibake detection)
@@ -65,6 +65,7 @@ export default [
       // Legacy pattern: obj.hasOwnProperty() used in existing code
       'no-prototype-builtins': 'off',
       // Existing code patterns — not worth fighting pre-modularisation
+      // (as of 2026-07: no-useless-assignment ×4, no-unsafe-finally ×1 in app.js/llm-client.js)
       'no-useless-assignment': 'off',
       'no-unsafe-finally': 'off',
       // Catch blocks that re-throw with a new message (without { cause })
@@ -86,7 +87,7 @@ export default [
     },
     rules: {
       ...js.configs.recommended.rules,
-      'no-unused-vars': ['warn', { args: 'none', caughtErrors: 'none' }],
+      'no-unused-vars': ['error', { args: 'none', caughtErrors: 'none' }],
       'no-undef': 'off'
     }
   },
@@ -103,7 +104,7 @@ export default [
     },
     rules: {
       ...js.configs.recommended.rules,
-      'no-unused-vars': ['warn', { args: 'none', caughtErrors: 'none' }]
+      'no-unused-vars': ['error', { args: 'none', caughtErrors: 'none' }]
     }
   },
 
@@ -117,7 +118,7 @@ export default [
     },
     rules: {
       ...js.configs.recommended.rules,
-      'no-unused-vars': ['warn', { args: 'none', caughtErrors: 'none' }],
+      'no-unused-vars': ['error', { args: 'none', caughtErrors: 'none' }],
     },
   },
 

--- a/js/secure-storage.js
+++ b/js/secure-storage.js
@@ -211,3 +211,6 @@ const SecureStorage = {
     });
   }
 };
+
+// 他モジュールと同じ公開イディオム（例: js/services/llm-client.js）
+window.SecureStorage = SecureStorage;


### PR DESCRIPTION
## 概要

リファクタ基盤づくりの一環として、ESLint をデッドコード検出のガードレールとして機能させます。

## 変更

- `no-unused-vars` を全4ブロック（browser JS / scripts ESM / scripts CJS / tests）で `warn` → `error` に昇格。ローカルで違反ゼロを確認済み。
- `js/secure-storage.js` に他モジュールと同じ公開イディオム `window.SecureStorage = SecureStorage;` を追加（llm-client.js:262, format-utils.js:38 と同形）。これが唯一残っていた unused-vars warning の解消にもなる。挙動は中立（top-level const は元々グローバルレキシカルスコープ経由で他ファイルから到達可能）。
- `no-useless-assignment`（現状違反4件）と `no-unsafe-finally`（同1件）は昇格せず、off のまま違反件数をコメントに記録。これらはコード修正が必要なため将来の専用PRとする。

## 検証

- `npx eslint .` — clean（0 errors, 0 warnings）
- `npm run test:unit` — 217 passed, 0 failed
- `npm run test:config-smoke` — pass

## メモ

調査で判明した `updateCostDisplayFromState`（app.js:5603）の死に分岐は、単なるデッドコードではなく「履歴復元後にコスト表示が更新されない」潜在バグだったため、別PR（fix）として分離します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)