### PR TITLE
fix(history): actually refresh cost display after restore

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -51,8 +51,7 @@ export default [
         OpenAIChunkedProvider: 'writable',
         // Cross-file references used with typeof checks
         DEFAULT_DICTIONARY: 'writable',
-        handleBackToMain: 'readonly',
-        updateCostDisplay: 'readonly'
+        handleBackToMain: 'readonly'
       }
     },
     rules: {

--- a/js/app.js
+++ b/js/app.js
@@ -5599,11 +5599,9 @@ function renderAIResponsesFromState() {
   }
 }
 
-// コスト表示更新
+// コスト表示更新（履歴・下書き復元後に AppState.costs を画面へ反映）
 function updateCostDisplayFromState() {
-  if (typeof updateCostDisplay === 'function') {
-    updateCostDisplay();
-  }
+  updateCosts();
 }
 
 // 履歴から復元


### PR DESCRIPTION
## 概要

履歴・アクティブ下書きから会議を復元したとき、コストパネルが更新されないバグを修正します。

## 原因

`updateCostDisplayFromState()`（app.js:5603）は `typeof updateCostDisplay === 'function'` のガード付きで `updateCostDisplay()` を呼んでいたが、この関数は**導入コミット（84762fd）の時点から一度も存在していない**（実在するのは `updateCosts()`）。ガードは常に false で、復元パス3箇所（下書き復元×2・履歴復元×1）でのコスト表示更新は無言のno-opだった。

## 変更

- `updateCostDisplayFromState()` の本体を `updateCosts()` 呼び出しに変更（3呼び出し箇所はそのまま）
- `eslint.config.mjs` から stale な `updateCostDisplay: 'readonly'` グローバルを削除

## 検証

- Playwright 実挙動検証: `AppState.costs` 設定 → `updateCostDisplayFromState()` → DOM反映を確認
  - totalCost: ¥0 → ¥50 / llmCostTotal: ¥42 / llmInputTokens: 1,234（修正前は変化なし）
- `npx eslint .` — 0 errors
- `npm run test:unit` — 217 passed, 0 failed

PR #162 の調査中に発見（当初は「デッドコード削除」の予定だったが、実際は潜在バグだったため fix として分離）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)