### PR TITLE
fix(security): add rel=noopener to remaining target=_blank links

### DIFF
--- a/index.html
+++ b/index.html
@@ -457,9 +457,9 @@
   <!-- フッター -->
   <footer style="text-align: center; padding: 1rem; font-size: 0.75rem; color: var(--text-secondary); border-top: 1px solid var(--border); background: var(--card-bg);">
     <div style="display: flex; justify-content: center; gap: 1.5rem; flex-wrap: wrap;">
-      <a href="docs/TERMS.md" target="_blank" style="color: var(--text-secondary); text-decoration: none;" data-i18n="footer.terms">利用規約</a>
-      <a href="docs/PRIVACY.md" target="_blank" style="color: var(--text-secondary); text-decoration: none;" data-i18n="footer.privacy">プライバシーポリシー</a>
-      <a href="docs/SECURITY.md" target="_blank" style="color: var(--text-secondary); text-decoration: none;" data-i18n="footer.security">セキュリティ</a>
+      <a href="docs/TERMS.md" target="_blank" rel="noopener" style="color: var(--text-secondary); text-decoration: none;" data-i18n="footer.terms">利用規約</a>
+      <a href="docs/PRIVACY.md" target="_blank" rel="noopener" style="color: var(--text-secondary); text-decoration: none;" data-i18n="footer.privacy">プライバシーポリシー</a>
+      <a href="docs/SECURITY.md" target="_blank" rel="noopener" style="color: var(--text-secondary); text-decoration: none;" data-i18n="footer.security">セキュリティ</a>
       <a href="https://github.com/gatyoukatyou/ai-meeting-assistant" target="_blank" rel="noopener" style="color: var(--text-secondary); text-decoration: none;">GitHub</a>
     </div>
     <div style="margin-top: 0.5rem;" data-i18n="footer.copyright">
@@ -499,7 +499,7 @@
           </div>
 
           <div style="margin-top: 1rem; font-size: 0.75rem; color: var(--text-secondary); text-align: center;">
-            利用開始により、<a href="docs/TERMS.md" target="_blank" style="color: var(--primary);">利用規約</a>と<a href="docs/PRIVACY.md" target="_blank" style="color: var(--primary);">プライバシーポリシー</a>に同意したものとみなされます。
+            利用開始により、<a href="docs/TERMS.md" target="_blank" rel="noopener" style="color: var(--primary);">利用規約</a>と<a href="docs/PRIVACY.md" target="_blank" rel="noopener" style="color: var(--primary);">プライバシーポリシー</a>に同意したものとみなされます。
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 概要

`target="_blank"` で開く内部ドキュメントリンク5箇所（フッター3件 + ウェルカムモーダル2件）に `rel="noopener"` を追加します。外部リンクはすべて付与済みだったため、これで index.html 内の `target="_blank"` 全6箇所が noopener 付きになります。

同一オリジンのため reverse-tabnabbing の実リスクは小さいですが、セキュリティレビューで挙がった一貫性ギャップを閉じるものです。

## 検証

- `grep` で `target="_blank"` 全6箇所すべてに `rel="noopener"` が付くことを確認
- `npm run test:ui-smoke` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)