### PR TITLE
fix(security): add CSP to 404.html and extract its inline script

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,6 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy"
+      content="default-src 'self'; base-uri 'self'; object-src 'none'; form-action 'self'; script-src 'self'; connect-src 'self' https://generativelanguage.googleapis.com https://api.openai.com https://api.groq.com https://api.anthropic.com wss://api.deepgram.com https://api.deepgram.com; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; manifest-src 'self';">
   <title data-i18n="notFound.pageTitle">ページが見つかりません - AI参加会議</title>
   <style>
     body {
@@ -56,17 +58,6 @@
 
   <!-- i18n (absolute path for GitHub Pages 404) -->
   <script src="/ai-meeting-assistant/js/i18n.js"></script>
-  <script>
-    // Initialize i18n and update title
-    document.addEventListener('DOMContentLoaded', async function() {
-      await I18n.init();
-      // Update document.title from data-i18n on title element
-      var titleEl = document.querySelector('title[data-i18n]');
-      if (titleEl) {
-        var key = titleEl.getAttribute('data-i18n');
-        if (key) document.title = t(key);
-      }
-    });
-  </script>
+  <script src="/ai-meeting-assistant/js/notfound.js"></script>
 </body>
 </html>

--- a/js/notfound.js
+++ b/js/notfound.js
@@ -1,0 +1,11 @@
+// 404ページ: i18n初期化とタイトル更新
+// (CSP script-src 'self' に対応するため 404.html のインラインスクリプトから移設)
+document.addEventListener('DOMContentLoaded', async function() {
+  await I18n.init();
+  // Update document.title from data-i18n on title element
+  var titleEl = document.querySelector('title[data-i18n]');
+  if (titleEl) {
+    var key = titleEl.getAttribute('data-i18n');
+    if (key) document.title = t(key);
+  }
+});

--- a/scripts/ui_smoke_check.mjs
+++ b/scripts/ui_smoke_check.mjs
@@ -67,6 +67,31 @@ if (indexHtml) {
   }
 }
 
+const notFoundPath = path.join(repoRoot, "404.html");
+const notFoundHtml = readFileOrError(notFoundPath, "404.html");
+
+if (notFoundHtml) {
+  const hasCsp = /<meta[^>]*http-equiv=["']Content-Security-Policy["']/i.test(notFoundHtml);
+  if (hasCsp) {
+    oks.push("Found CSP meta in 404.html");
+  } else {
+    errors.push("Missing Content-Security-Policy meta in 404.html");
+  }
+
+  // CSP script-src 'self' の下では実行されないため、本文つきインライン<script>を禁止する
+  const scriptTags = notFoundHtml.match(/<script\b[^>]*>[\s\S]*?<\/script>/gi) || [];
+  const inlineScripts = scriptTags.filter((tag) => {
+    const hasSrc = /<script\b[^>]*\ssrc=/i.test(tag);
+    const body = tag.replace(/^<script\b[^>]*>/i, "").replace(/<\/script>$/i, "");
+    return !hasSrc && body.trim().length > 0;
+  });
+  if (inlineScripts.length === 0) {
+    oks.push("No inline <script> bodies in 404.html");
+  } else {
+    errors.push(`Found ${inlineScripts.length} inline <script> body(ies) in 404.html (blocked by CSP script-src 'self')`);
+  }
+}
+
 if (themeJs) {
   const hasAppStyle = /appStyle/.test(themeJs);
   const hasDisplayTheme = /display_theme/.test(themeJs);


### PR DESCRIPTION
## 概要

セキュリティレビューで挙がったCSPポスチャの穴を閉じます。`404.html` だけが index.html / config.html と同じCSPメタを持っていませんでした。

## 変更

- `404.html` に index.html:6 と同一のCSPメタを追加
- `script-src 'self'` 下ではインラインスクリプトが実行されないため、i18nタイトル設定処理を新規 `js/notfound.js` へ移設（i18n.js と同じ GitHub Pages 用絶対パスで読み込み）。ロジックは無変更
- `scripts/ui_smoke_check.mjs` に回帰ガードを追加: 「404.htmlにCSPメタがある」「本文つきインライン`<script>`がない」

## 検証

- Playwright + GitHub Pages 同等の `/ai-meeting-assistant/` プレフィックス付き静的サーバで404ページを実表示:
  - CSP違反 0件 / ページエラー 0件
  - タイトルがi18nから正しく設定（`404 - AI参加会議`）＝移設スクリプトが動作
- `npm run test:ui-smoke` — pass（新アサート含む）
- `npx eslint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)