### PR TITLE
fix(stt): cancel Deepgram reconnect timer on stop (zombie connection)

### DIFF
--- a/js/stt/providers/deepgram_ws.js
+++ b/js/stt/providers/deepgram_ws.js
@@ -24,6 +24,8 @@ class DeepgramWSProvider {
     this.reconnectAttempts = 0;
     this.maxReconnectAttempts = 3;
     this._connectTimer = null;
+    this._reconnectTimer = null;
+    this._stopped = false;
 
     // Utteranceバッファリング（断片化防止）
     this._finalBuffer = '';        // is_final=trueの断片を蓄積
@@ -43,6 +45,9 @@ class DeepgramWSProvider {
     if (!this.apiKey) {
       throw new Error('Deepgram API key is required');
     }
+
+    // 停止フラグをリセット（新規開始）
+    this._stopped = false;
 
     // バッファをリセット
     this._finalBuffer = '';
@@ -86,6 +91,17 @@ class DeepgramWSProvider {
           clearTimeout(this._connectTimer);
           this._connectTimer = null;
         }
+        // stop() が接続中に呼ばれていたら、開いたソケットを即座に閉じる
+        if (this._stopped) {
+          DebugLogger.log('[Deepgram]', 'Opened after stop, closing immediately');
+          try {
+            ws.close(1000, 'Stopped during connect');
+          } catch (e) {
+            // Ignore close errors
+          }
+          resolve();
+          return;
+        }
         DebugLogger.log('[Deepgram]', 'WebSocket connected');
         this.isConnected = true;
         this.reconnectAttempts = 0;
@@ -114,11 +130,16 @@ class DeepgramWSProvider {
         // 残っているバッファがあればフラッシュ
         this._flushFinalBuffer();
 
-        if (event.code !== 1000 && this.reconnectAttempts < this.maxReconnectAttempts) {
+        if (!this._stopped && event.code !== 1000 && this.reconnectAttempts < this.maxReconnectAttempts) {
           this.reconnectAttempts++;
           DebugLogger.log('[Deepgram]', 'Attempting reconnect (' + this.reconnectAttempts + '/' + this.maxReconnectAttempts + ')');
           this.updateStatus('reconnecting');
-          setTimeout(() => this.start().catch(console.error), 1000 * this.reconnectAttempts);
+          this._reconnectTimer = setTimeout(() => {
+            this._reconnectTimer = null;
+            // stop() がバックオフ中に呼ばれていたら再接続しない（ゾンビ接続防止）
+            if (this._stopped) return;
+            this.start().catch(console.error);
+          }, 1000 * this.reconnectAttempts);
         } else {
           this.updateStatus('disconnected');
         }
@@ -146,10 +167,19 @@ class DeepgramWSProvider {
    * WebSocket接続を停止
    */
   async stop() {
+    // 停止フラグを立てる（バックオフ中の再接続コールバックを無効化）
+    this._stopped = true;
+
     // Clear connection timer
     if (this._connectTimer) {
       clearTimeout(this._connectTimer);
       this._connectTimer = null;
+    }
+
+    // Clear pending reconnect timer (ゾンビ接続防止)
+    if (this._reconnectTimer) {
+      clearTimeout(this._reconnectTimer);
+      this._reconnectTimer = null;
     }
 
     // 残っているバッファをフラッシュ

--- a/tests/unit/deepgram-ws-reconnect.test.mjs
+++ b/tests/unit/deepgram-ws-reconnect.test.mjs
@@ -1,0 +1,188 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadScript } from '../helpers/load-script.mjs';
+
+/**
+ * Fake WebSocket capturing constructions, sends, and close calls.
+ * Provides _open()/_close() helpers to drive the provider's lifecycle handlers.
+ */
+class FakeWebSocket {
+  constructor(url, protocols) {
+    FakeWebSocket.instances.push(this);
+    this.url = url;
+    this.protocols = protocols;
+    this.readyState = FakeWebSocket.CONNECTING;
+    this.sent = [];
+    this.closeCalls = [];
+    this.onopen = null;
+    this.onmessage = null;
+    this.onerror = null;
+    this.onclose = null;
+  }
+
+  send(data) {
+    this.sent.push(data);
+  }
+
+  close(code, reason) {
+    this.closeCalls.push({ code, reason });
+    this.readyState = FakeWebSocket.CLOSED;
+  }
+
+  // Test helpers
+  _open() {
+    this.readyState = FakeWebSocket.OPEN;
+    if (this.onopen) this.onopen();
+  }
+
+  _fireClose(code) {
+    this.readyState = FakeWebSocket.CLOSED;
+    if (this.onclose) this.onclose({ code });
+  }
+}
+FakeWebSocket.CONNECTING = 0;
+FakeWebSocket.OPEN = 1;
+FakeWebSocket.CLOSING = 2;
+FakeWebSocket.CLOSED = 3;
+
+const CONNECT_TIMEOUT_DELAY = 10000;
+
+/**
+ * Build a fresh sandboxed provider with a controllable timer harness and a
+ * fake WebSocket. Reconnect timers use delay < CONNECT_TIMEOUT_DELAY; the
+ * connection timeout uses exactly CONNECT_TIMEOUT_DELAY.
+ */
+function createProvider() {
+  FakeWebSocket.instances = [];
+
+  const timers = new Map();
+  let nextId = 1;
+  const fakeSetTimeout = (fn, delay) => {
+    const id = nextId++;
+    timers.set(id, { fn, delay });
+    return id;
+  };
+  const fakeClearTimeout = (id) => {
+    timers.delete(id);
+  };
+
+  // Return the queued reconnect timer callbacks (excludes the 10s connect timeout)
+  const pendingReconnectTimers = () =>
+    [...timers.values()].filter((t) => t.delay < CONNECT_TIMEOUT_DELAY);
+
+  // Fire all pending reconnect timers (mirrors the browser clock advancing)
+  const fireReconnectTimers = () => {
+    for (const [id, t] of [...timers]) {
+      if (t.delay < CONNECT_TIMEOUT_DELAY) {
+        timers.delete(id);
+        t.fn();
+      }
+    }
+  };
+
+  const SecureStorage = {
+    getApiKey() {
+      return 'test-deepgram-key';
+    },
+    getModel() {
+      return 'nova-3-general';
+    }
+  };
+  const DebugLogger = { log() {}, error() {} };
+  const window = {};
+
+  loadScript('js/stt/providers/deepgram_ws.js', {
+    window,
+    SecureStorage,
+    DebugLogger,
+    WebSocket: FakeWebSocket,
+    URL,
+    setTimeout: fakeSetTimeout,
+    clearTimeout: fakeClearTimeout,
+    console: { error() {}, log() {} }
+  });
+
+  const provider = new window.DeepgramWSProvider({ apiKey: 'test-deepgram-key' });
+
+  return {
+    provider,
+    timers,
+    pendingReconnectTimers,
+    fireReconnectTimers
+  };
+}
+
+// Start the provider and drive the socket to the open/connected state.
+async function startConnected(provider) {
+  const p = provider.start();
+  const ws = FakeWebSocket.instances.at(-1);
+  ws._open();
+  await p;
+  return ws;
+}
+
+describe('DeepgramWSProvider reconnect zombie fix', () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+  });
+
+  it('schedules a reconnect on a non-1000 close and re-invokes start() when the timer fires', async () => {
+    const { provider, pendingReconnectTimers, fireReconnectTimers } = createProvider();
+
+    const ws = await startConnected(provider);
+    assert.equal(FakeWebSocket.instances.length, 1);
+
+    // Abnormal close -> should schedule a reconnect timer
+    ws._fireClose(1011);
+    assert.equal(pendingReconnectTimers().length, 1, 'a reconnect timer should be queued');
+
+    // Firing the timer should re-invoke start() -> a new socket is created
+    fireReconnectTimers();
+    assert.equal(FakeWebSocket.instances.length, 2, 'start() should have been re-invoked');
+  });
+
+  it('stop() before the reconnect timer fires cancels it (start() NOT re-invoked)', async () => {
+    const { provider, pendingReconnectTimers, fireReconnectTimers } = createProvider();
+
+    const ws = await startConnected(provider);
+    ws._fireClose(1011);
+    assert.equal(pendingReconnectTimers().length, 1);
+
+    await provider.stop();
+    assert.equal(pendingReconnectTimers().length, 0, 'stop() should clear the reconnect timer');
+
+    // Even if the clock advances, nothing should fire.
+    fireReconnectTimers();
+    assert.equal(FakeWebSocket.instances.length, 1, 'no new socket after stop()');
+  });
+
+  it('_stopped guard prevents reconnect when a stray timer fires after stop()', async () => {
+    const { provider, timers } = createProvider();
+
+    const ws = await startConnected(provider);
+    ws._fireClose(1011);
+
+    // Capture the reconnect callback before stop() clears the timer,
+    // simulating a timer that already fired / is mid-flight during stop().
+    const reconnectCb = [...timers.values()].find(
+      (t) => t.delay < CONNECT_TIMEOUT_DELAY
+    ).fn;
+
+    await provider.stop();
+
+    // Manually invoke the stray callback -> the _stopped guard must bail.
+    reconnectCb();
+    assert.equal(FakeWebSocket.instances.length, 1, 'guard must block reconnect after stop()');
+  });
+
+  it('does not schedule a reconnect on a normal (code 1000) close', async () => {
+    const { provider, pendingReconnectTimers, fireReconnectTimers } = createProvider();
+
+    const ws = await startConnected(provider);
+    ws._fireClose(1000);
+
+    assert.equal(pendingReconnectTimers().length, 0, 'normal close must not schedule a reconnect');
+    fireReconnectTimers();
+    assert.equal(FakeWebSocket.instances.length, 1, 'no reconnect for normal close');
+  });
+});


### PR DESCRIPTION
## 概要

Deepgram WebSocket プロバイダーの「ゾンビ再接続」レースを修正する。バックオフ再接続待機中に `stop()` を呼んでも、停止済みのはずのソケットが再オープンされる問題を解消。

## 原因

`js/stt/providers/deepgram_ws.js` の `ws.onclose` は、非正常終了(code !== 1000)時に
`setTimeout(() => this.start().catch(console.error), 1000 * this.reconnectAttempts)` で
再接続をスケジュールしていたが、**タイマーハンドルを保持していなかった**。
一方 `stop()` は `_connectTimer` しかクリアしないため、バックオフ待機中に `stop()` を
呼んでもタイマーが生き残り、`start()` が発火して新しい WebSocket を開いてしまう
（アプリは停止済みと認識しているのに接続が復活する = ゾンビ接続）。

## 変更

- コンストラクタに `_reconnectTimer` と `_stopped` を追加（既存フィールドと並べて初期化）。
- `ws.onclose` の再接続 `setTimeout` を `this._reconnectTimer` に保持し、コールバック内で
  `_stopped` を確認してから `start()` を呼ぶ（発火直前に stop() された場合の保険）。
- `stop()` で `_stopped = true` を立て、`_reconnectTimer` を clear + null（`_connectTimer` と同じ扱い）。
- `start()` の先頭で `_stopped = false` にリセット（再利用時のライフサイクル対応）。
- `ws.onopen` で `_stopped` が立っていたら開いたソケットを即座に close（接続確立中に stop() された場合の保険）。

**バックオフのタイミング/上限(`maxReconnectAttempts`, `1000 * attempts`)、`_connectTimer` ロジック、
バッファフラッシュ挙動は変更していない。** 最小差分。

## 検証

- `npx eslint .` → 0 errors（`SecureStorage` の未使用警告1件は main 既存のもの）。
- `npm run test:unit` → 221 tests, 全 pass（新規テスト含む）。
- `git diff --check` → clean。

新規テスト `tests/unit/deepgram-ws-reconnect.test.mjs`（node:test + node:assert/strict、
既存の `tests/helpers/load-script.mjs` サンドボックスを使用、Fake WebSocket と制御可能な
setTimeout/clearTimeout を注入）:

1. `schedules a reconnect on a non-1000 close and re-invokes start() when the timer fires` — 非正常終了で再接続がスケジュールされ、タイマー発火で start() が再呼び出しされる。
2. `stop() before the reconnect timer fires cancels it (start() NOT re-invoked)` — バックオフ中の stop() でタイマーがキャンセルされ、start() が再呼び出しされない。
3. `_stopped guard prevents reconnect when a stray timer fires after stop()` — stop() 後に取り残されたタイマーが発火しても `_stopped` ガードで再接続しない。
4. `does not schedule a reconnect on a normal (code 1000) close` — 正常終了(1000)では再接続をスケジュールしない（既存挙動）。

結果: 4/4 pass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)