### PR TITLE
fix(stability): keep history/IndexedDB failures recoverable (toast, not fatal modal)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5613,7 +5613,14 @@ async function restoreFromHistory(recordId) {
     return;
   }
 
-  const record = await HistoryStore.get(recordId);
+  let record;
+  try {
+    record = await HistoryStore.get(recordId);
+  } catch (err) {
+    console.error('[History] Failed to load record for restore', err);
+    showToast(t('toast.history.failed', { message: err.message || 'Unknown error' }), 'error');
+    return;
+  }
   if (!record) {
     showToast(t('toast.history.failed', { message: t('history.missingRecord') }), 'error');
     return;
@@ -5898,7 +5905,14 @@ async function renderHistoryList() {
     return;
   }
 
-  const records = await HistoryStore.list();
+  let records;
+  try {
+    records = await HistoryStore.list();
+  } catch (err) {
+    console.error('[History] Failed to list records', err);
+    showToast(t('toast.history.failed', { message: err.message || 'Unknown error' }), 'error');
+    return;
+  }
   if (!records.length) {
     const empty = document.createElement('p');
     empty.style.color = 'var(--text-secondary)';
@@ -5998,7 +6012,14 @@ function handleHistoryListAction(event) {
 
 async function downloadHistoryRecord(id) {
   if (!id || typeof HistoryStore === 'undefined') return;
-  const record = await HistoryStore.get(id);
+  let record;
+  try {
+    record = await HistoryStore.get(id);
+  } catch (err) {
+    console.error('[History] Failed to load record for download', err);
+    showToast(t('toast.history.failed', { message: err.message || 'Unknown error' }), 'error');
+    return;
+  }
   if (!record || !record.exportMarkdown) {
     showToast(t('toast.history.failed', { message: t('history.missingRecord') }), 'error');
     return;
@@ -6009,7 +6030,13 @@ async function downloadHistoryRecord(id) {
 
 async function deleteHistoryRecord(id) {
   if (!id || typeof HistoryStore === 'undefined') return;
-  await HistoryStore.delete(id);
+  try {
+    await HistoryStore.delete(id);
+  } catch (err) {
+    console.error('[History] Failed to delete record', err);
+    showToast(t('toast.history.failed', { message: err.message || 'Unknown error' }), 'error');
+    return;
+  }
   showToast(t('toast.history.deleted'), 'info');
   await renderHistoryList();
 }
@@ -6019,7 +6046,13 @@ async function clearHistoryRecords() {
   if (!confirm(t('history.clearConfirm'))) {
     return;
   }
-  await HistoryStore.clear();
+  try {
+    await HistoryStore.clear();
+  } catch (err) {
+    console.error('[History] Failed to clear records', err);
+    showToast(t('toast.history.failed', { message: err.message || 'Unknown error' }), 'error');
+    return;
+  }
   showToast(t('toast.history.cleared'), 'info');
   await renderHistoryList();
 }
@@ -6043,7 +6076,14 @@ async function downloadHistoryBackup() {
     return false;
   }
 
-  const records = await HistoryStore.list();
+  let records;
+  try {
+    records = await HistoryStore.list();
+  } catch (err) {
+    console.error('[HistoryBackup] Failed to list records', err);
+    showToast(t('toast.history.failed', { message: err.message || 'Unknown error' }), 'error');
+    return false;
+  }
   if (!records.length) {
     showToast(t('history.backupNoRecords'), 'warning');
     return false;


### PR DESCRIPTION
## 概要
履歴（IndexedDB / `HistoryStore`）操作の失敗が unhandled rejection としてグローバルハンドラに到達し、全画面の致命的エラーモーダル（`#fatalErrorModal`）表示＋録音強制停止を引き起こす問題を修正。失敗は回復可能なエラーとしてトースト表示のみに留める。

安定化リファクタリング計画の PR 5。

## 原因
`window.onunhandledrejection`（js/app.js:350-352）はあらゆる unhandled rejection を `handleFatalError` にルーティングする。履歴系の async 関数に `HistoryStore` への await がガードなしで存在し、IndexedDB エラー時の reject がそのままグローバルハンドラへ到達していた。

## 変更（対象関数の一覧）
`saveHistorySnapshot` の既存パターン（try/catch + `showToast(t('toast.history.failed', ...))`）を踏襲し、以下の関数のガードなし await をローカル try/catch で保護。文言・i18n キーの追加変更なし（既存キー再利用）。`handleFatalError` / `window.onunhandledrejection` 自体は変更なし。

- `renderHistoryList` — `HistoryStore.list()` をガード。呼び出し元の `openHistoryModal` / `refreshHistoryListIfOpen` / `deleteHistoryRecord`・`clearHistoryRecords` の再描画・`importHistoryBackupFromFile` も自動的に安全化（二重トースト回避のため最内でガードし rethrow しない）
- `restoreFromHistory` — `HistoryStore.get(recordId)` をガード
- `downloadHistoryRecord` — `HistoryStore.get(id)` をガード
- `deleteHistoryRecord` — `HistoryStore.delete(id)` をガード
- `clearHistoryRecords` — `HistoryStore.clear()` をガード
- `downloadHistoryBackup` — `HistoryStore.list()` をガード（`false` を返却）

指示リスト外で発見したガードなしサイト: `downloadHistoryBackup`（app.js 旧 6046 行の `HistoryStore.list()` の実体はこの関数）。なお以下は既にガード済みのため変更なし: `promptForActiveMeetingDraftIfNeeded`（try/catch 済み）、`buildDiagnosticPackData`（try/catch 済み）、`saveHistorySnapshot`（参照パターン）、`clearActiveMeetingDraft`/`saveActiveMeetingDraftNow`（呼び出し元で `.catch` 済みまたは録音停止フロー内で処理）。

## 検証
1. `npx eslint .` — 0 errors（既存の SecureStorage warning 1件のみ、main と同一）
2. `npm run test:unit` — 217 tests / 217 pass / 0 fail
3. `git diff --check` — clean
4. Playwright 動作検証（使い捨てスクリプト、コミット対象外）: `HistoryStore.list/get/delete/clear` 等を reject するよう差し替え、各履歴 UI 操作を実行。全ケースで「トースト表示あり・`#fatalErrorModal` 非表示・unhandledrejection 到達ゼロ」を確認:

```
[PASS] openHistoryModal (list rejects) :: toast="❌履歴処理に失敗しました: Simulated IndexedDB failure" fatalVisible=false unhandled=[]
[PASS] renderHistoryList (list rejects) :: toast="❌履歴処理に失敗しました: Simulated IndexedDB failure" fatalVisible=false unhandled=[]
[PASS] restoreFromHistory (get rejects) :: toast="❌履歴処理に失敗しました: Simulated IndexedDB failure" fatalVisible=false unhandled=[]
[PASS] downloadHistoryRecord (get rejects) :: toast="❌履歴処理に失敗しました: Simulated IndexedDB failure" fatalVisible=false unhandled=[]
[PASS] deleteHistoryRecord (delete rejects) :: toast="❌履歴処理に失敗しました: Simulated IndexedDB failure" fatalVisible=false unhandled=[]
[PASS] clearHistoryRecords (clear rejects) :: toast="❌履歴処理に失敗しました: Simulated IndexedDB failure" fatalVisible=false unhandled=[]
[PASS] downloadHistoryBackup (list rejects) :: toast="❌履歴処理に失敗しました: Simulated IndexedDB failure" fatalVisible=false unhandled=[]

=== 7/7 cases passed ===
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)