### PR TITLE
fix(stability): guard localStorage writes against quota/private-mode failures

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -55,6 +55,14 @@
 - 一般的な問題: [GitHub Issues](https://github.com/gatyoukatyou/ai-meeting-assistant/issues)
 - 深刻な脆弱性: [Security Advisories](https://github.com/gatyoukatyou/ai-meeting-assistant/security/advisories/new)
 
+### 脅威モデル（技術的補足）
+- APIキーはWeb Storage（既定はsessionStorage、記憶ON設定時はlocalStorage）に**平文**で保存されます。暗号化は行っていません
+- 同一オリジンで実行されるスクリプト（本アプリ自身のバグやXSS）はWeb Storageを読み取れます。この対策として、厳格なCSPと一貫したエスケープ処理によりXSSの混入自体を防ぐ設計としています
+- sessionStorageは既定でタブ/ブラウザを閉じると消去され、平文データが残る期間を限定します
+- 記憶（persistApiKeys）オプションはユーザーの明示的なオプトインが必要で、対応環境（デスクトップアプリ表示モードなど）に限定してのみ有効化されます
+- WebCrypto等によるクライアントサイド暗号化は検討しましたが、復号鍵も同一オリジンのJavaScriptから参照可能である以上、アプリ自身のオリジンを起点とする攻撃（XSS等）に対しては保護効果がないため、実装を見送りました
+- Web Storageへの書き込み（`localStorage.setItem`等）はストレージ容量超過やSafariプライベートモード等で例外を投げる場合があります。本アプリはこれらの例外を捕捉し、保存に失敗してもアプリの動作は継続する設計です（データは保存されない場合があります）
+
 ---
 
 ## English

--- a/js/app.js
+++ b/js/app.js
@@ -1085,7 +1085,11 @@ document.addEventListener('DOMContentLoaded', async function() {
   const hasVisited = localStorage.getItem('_visited');
   if (!hasVisited) {
     document.getElementById('welcomeModal').classList.add('active');
-    localStorage.setItem('_visited', 'true');
+    try {
+      localStorage.setItem('_visited', 'true');
+    } catch (e) {
+      console.warn('[Storage] Failed to persist _visited flag', e);
+    }
   }
 
   // ブラウザを閉じる前のクリーンアップ
@@ -3920,7 +3924,11 @@ function switchMainTab(tabName) {
   if (AppState.isPanelMeetingMode) {
     AppState.isPanelMeetingMode = false;
     document.querySelector('.main-container')?.classList.remove('meeting-mode');
-    localStorage.setItem('_panelMeetingMode', '0');
+    try {
+      localStorage.setItem('_panelMeetingMode', '0');
+    } catch (e) {
+      console.warn('[Storage] Failed to persist panelMeetingMode', e);
+    }
     updatePanelMeetingModeUI();
   }
 
@@ -4087,7 +4095,11 @@ function initPanelMeetingMode() {
 function togglePanelMeetingMode() {
   AppState.isPanelMeetingMode = !AppState.isPanelMeetingMode;
   document.querySelector('.main-container')?.classList.toggle('meeting-mode', AppState.isPanelMeetingMode);
-  localStorage.setItem('_panelMeetingMode', AppState.isPanelMeetingMode ? '1' : '0');
+  try {
+    localStorage.setItem('_panelMeetingMode', AppState.isPanelMeetingMode ? '1' : '0');
+  } catch (e) {
+    console.warn('[Storage] Failed to persist panelMeetingMode', e);
+  }
   updatePanelMeetingModeUI();
 }
 
@@ -6736,7 +6748,11 @@ function persistMeetingContext() {
     } else {
       const primary = persist ? localStorage : sessionStorage;
       const secondary = persist ? sessionStorage : localStorage;
-      primary.setItem('_meetingContext', serialized);
+      try {
+        primary.setItem('_meetingContext', serialized);
+      } catch (e) {
+        console.warn('[Context] Failed to persist meeting context', e);
+      }
       primary.removeItem('__meetingContext');
       secondary.removeItem('_meetingContext');
       secondary.removeItem('__meetingContext');

--- a/js/secure-storage.js
+++ b/js/secure-storage.js
@@ -1,5 +1,8 @@
 // =====================================
-// セキュリティ：保存管理モジュール
+// ストレージ管理モジュール
+// 注意：APIキーはWeb Storage（既定はsessionStorage、記憶ON時はlocalStorage）に
+// 平文で保存されます。本モジュールは保存先の切り替え等を管理するもので、
+// 暗号化は行いません。脅威モデルの詳細は docs/SECURITY.md を参照してください。
 // =====================================
 const SecureStorage = {
   // API key storage providers list
@@ -7,6 +10,20 @@ const SecureStorage = {
     (typeof ProviderCatalog !== 'undefined' && typeof ProviderCatalog.getApiKeyProviderIds === 'function')
       ? ProviderCatalog.getApiKeyProviderIds()
       : ['gemini', 'claude', 'openai_llm', 'groq', 'openai', 'deepgram'],
+
+  // Web Storageのwrite系呼び出しはQuotaExceededError等で例外を投げることがある
+  // （Safariプライベートモード、ストレージ容量超過など）。失敗してもアプリの
+  // 動作を継続させるため、ここで捕捉して呼び出し元へは伝播させない。
+  // 値（APIキー等）が漏れないよう、失敗ログにはキー名のみを出力する。
+  _safeSetItem: function(storage, key, value) {
+    try {
+      storage.setItem(key, value);
+      return true;
+    } catch (e) {
+      console.warn(`[SecureStorage] Failed to persist "${key}" (storage full or unavailable)`);
+      return false;
+    }
+  },
 
   isPersistentApiKeysSupported: function() {
     if (typeof window === 'undefined' || typeof navigator === 'undefined') return false;
@@ -47,7 +64,7 @@ const SecureStorage = {
       storages.secondary.removeItem(storageKey);
       return;
     }
-    storages.primary.setItem(storageKey, key);
+    this._safeSetItem(storages.primary, storageKey, key);
     // Keep a single source of truth for API keys.
     storages.secondary.removeItem(storageKey);
   },
@@ -60,7 +77,7 @@ const SecureStorage = {
 
   // モデルを保存（暗号化不要）
   setModel: function(provider, model) {
-    localStorage.setItem(`_m_${provider}`, model);
+    this._safeSetItem(localStorage, `_m_${provider}`, model);
   },
 
   getModel: function(provider) {
@@ -73,7 +90,7 @@ const SecureStorage = {
       localStorage.removeItem(`_mc_${provider}`);
       return;
     }
-    localStorage.setItem(`_mc_${provider}`, model.trim());
+    this._safeSetItem(localStorage, `_mc_${provider}`, model.trim());
   },
 
   getCustomModel: function(provider) {
@@ -91,7 +108,7 @@ const SecureStorage = {
 
   // オプションを保存
   setOption: function(key, value) {
-    localStorage.setItem(`_opt_${key}`, JSON.stringify(value));
+    this._safeSetItem(localStorage, `_opt_${key}`, JSON.stringify(value));
   },
 
   getOption: function(key, defaultValue) {

--- a/js/secure-storage.js
+++ b/js/secure-storage.js
@@ -64,9 +64,10 @@ const SecureStorage = {
       storages.secondary.removeItem(storageKey);
       return;
     }
-    this._safeSetItem(storages.primary, storageKey, key);
-    // Keep a single source of truth for API keys.
-    storages.secondary.removeItem(storageKey);
+    if (this._safeSetItem(storages.primary, storageKey, key)) {
+      // Keep a single source of truth only after the new value is persisted.
+      storages.secondary.removeItem(storageKey);
+    }
   },
 
   // APIキーを取得

--- a/tests/unit/secure-storage.test.mjs
+++ b/tests/unit/secure-storage.test.mjs
@@ -134,6 +134,18 @@ describe('SecureStorage degrades gracefully on storage write failures', () => {
     });
   });
 
+  it('keeps the secondary API key when the target storage write fails', () => {
+    const { SecureStorage, localStorage, sessionStorage } = createSecureStorageContext({
+      localData: { _ak_openai: 'existing-key' },
+      sessionThrowsOnSetItem: true
+    });
+
+    SecureStorage.setApiKey('openai', 'new-key');
+
+    assert.equal(sessionStorage.getItem('_ak_openai'), null);
+    assert.equal(localStorage.getItem('_ak_openai'), 'existing-key');
+  });
+
   it('setApiKey does not throw when the persistent (localStorage) target throws', () => {
     // Preset the persist option directly (rather than via setPersistApiKeys)
     // so the write failure under test is isolated to setApiKey itself.

--- a/tests/unit/secure-storage.test.mjs
+++ b/tests/unit/secure-storage.test.mjs
@@ -2,13 +2,16 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { loadScript } from '../helpers/load-script.mjs';
 
-function createStorage(initial = {}) {
+function createStorage(initial = {}, { throwOnSetItem = false } = {}) {
   const store = new Map(Object.entries(initial));
   return {
     getItem(key) {
       return store.has(key) ? store.get(key) : null;
     },
     setItem(key, value) {
+      if (throwOnSetItem) {
+        throw new DOMException('QuotaExceededError', 'QuotaExceededError');
+      }
       store.set(key, String(value));
     },
     removeItem(key) {
@@ -25,10 +28,12 @@ function createSecureStorageContext({
   isWindowControlsOverlay = false,
   userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0)',
   localData = {},
-  sessionData = {}
+  sessionData = {},
+  localThrowsOnSetItem = false,
+  sessionThrowsOnSetItem = false
 } = {}) {
-  const localStorage = createStorage(localData);
-  const sessionStorage = createStorage(sessionData);
+  const localStorage = createStorage(localData, { throwOnSetItem: localThrowsOnSetItem });
+  const sessionStorage = createStorage(sessionData, { throwOnSetItem: sessionThrowsOnSetItem });
   const window = {
     matchMedia(query) {
       if (query === '(display-mode: standalone)') {
@@ -115,5 +120,53 @@ describe('SecureStorage persistApiKeys policy', () => {
     const exported = SecureStorage.exportAll();
 
     assert.equal(exported.options.persistApiKeys, true);
+  });
+});
+
+describe('SecureStorage degrades gracefully on storage write failures', () => {
+  it('setApiKey does not throw when the target storage.setItem throws (quota/private mode)', () => {
+    const { SecureStorage } = createSecureStorageContext({
+      sessionThrowsOnSetItem: true
+    });
+
+    assert.doesNotThrow(() => {
+      SecureStorage.setApiKey('openai', 'some-key');
+    });
+  });
+
+  it('setApiKey does not throw when the persistent (localStorage) target throws', () => {
+    // Preset the persist option directly (rather than via setPersistApiKeys)
+    // so the write failure under test is isolated to setApiKey itself.
+    const { SecureStorage } = createSecureStorageContext({
+      isStandalone: true,
+      localData: { _opt_persistApiKeys: 'true' },
+      localThrowsOnSetItem: true
+    });
+
+    assert.equal(SecureStorage.isPersistApiKeysEnabled(), true);
+    assert.doesNotThrow(() => {
+      SecureStorage.setApiKey('openai', 'some-key');
+    });
+  });
+
+  it('setModel does not throw when localStorage.setItem throws', () => {
+    const { SecureStorage } = createSecureStorageContext({
+      localThrowsOnSetItem: true
+    });
+
+    assert.doesNotThrow(() => {
+      SecureStorage.setModel('gemini', 'gemini-pro');
+    });
+  });
+
+  it('setOption does not throw when localStorage.setItem throws, and getOption falls back to the default', () => {
+    const { SecureStorage } = createSecureStorageContext({
+      localThrowsOnSetItem: true
+    });
+
+    assert.doesNotThrow(() => {
+      SecureStorage.setOption('costLimit', 500);
+    });
+    assert.equal(SecureStorage.getOption('costLimit', 100), 100);
   });
 });


### PR DESCRIPTION
## 概要

同期的な `localStorage.setItem` / `sessionStorage.setItem` は QuotaExceededError（容量超過）や Safari プライベートモードで例外を投げることがあり、現状ではその例外がグローバルエラーハンドラまで伝播して全画面の致命的エラーモーダルが表示されていました。書き込み失敗時は警告ログのみでアプリの動作を継続するよう、書き込み箇所をガードします。あわせて `js/secure-storage.js` の「セキュリティ」という誤解を招くコメントを訂正し（APIキーは平文保存）、脅威モデルを docs/SECURITY.md に明文化しました。

## 変更

- **js/secure-storage.js**
  - private ヘルパー `_safeSetItem(storage, key, value)` を追加（try/catch、boolean返却、失敗時はキー名のみを console.warn — 値=APIキーはログに出さない）
  - `setApiKey` / `setModel` / `setCustomModel` / `setOption` の書き込みをヘルパー経由に変更（公開APIと返り値は不変）
  - ヘッダーコメントを訂正: 本モジュールは保存先管理であり暗号化は行わず、APIキーは Web Storage（既定 sessionStorage、記憶ON時 localStorage）に平文で保存される旨を明記
- **js/app.js**（生の localStorage.setItem 4箇所に局所 try/catch + console.warn）
  - L1088付近: 初回訪問フラグ `_visited` の保存
  - L3923付近: `switchMainTab()` 内の `_panelMeetingMode` リセット
  - L4090付近: `togglePanelMeetingMode()` 内の `_panelMeetingMode` 保存
  - L6739付近: `persistMeetingContext()` の MeetingContextStore 不在時フォールバック（`_meetingContext` 書き込み。重複実装のリファクタは行わずガードのみ）
- **docs/SECURITY.md**: 「脅威モデル（技術的補足）」節を追加（平文保存の事実、同一オリジンスクリプト/XSSからの読み取りとCSP・エスケープによる緩和、sessionStorage既定による残存期間の限定、persistオプションのオプトイン+UAゲート、WebCrypto暗号化を見送った理由）
- **tests/unit/secure-storage.test.mjs**: `setItem` が例外を投げるストレージスタブを追加し、`setApiKey`（session/local両系統）・`setModel`・`setOption` が例外を伝播しないことを検証するテスト4件を追加

トースト文言・i18nキー・ストレージキー・persist トグルのセマンティクスは一切変更していません。

## 検証

- `npx eslint .` : 0 errors（main 由来の既存 `SecureStorage` unused-vars warning 1件のみ）
- `npm run test:unit` : **221 tests / 58 suites 全パス**（新規4件含む、fail 0）
- `npm run test:config-smoke` : パス
- `bash scripts/check-docs-consistency.sh` : Errors: 0 / Warnings: 0 [PASSED]
- `git diff --check` : クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)