### PR TITLE
feat(recording): 録音の最大時間設定と自動停止（既定120分）

### DIFF
--- a/config.html
+++ b/config.html
@@ -318,6 +318,17 @@
         </div>
       </div>
 
+      <div class="security-options accent-blue">
+        <div class="security-options-title">⏱️ <span data-i18n="config.options.recordingLimitTitle">Recording Limit</span></div>
+        <div class="setting-group" style="margin-bottom: 0.5rem;">
+          <label class="setting-label" style="font-size: 0.8rem;" data-i18n="config.options.maxRecordingMinutes">Max recording duration (minutes)</label>
+          <input type="number" class="setting-input" id="maxRecordingMinutes" data-i18n-placeholder="config.options.maxRecordingMinutesPlaceholder" placeholder="e.g. 120" value="120" min="0" step="10" style="max-width: 150px;">
+        </div>
+        <div class="setting-hint" data-i18n="config.options.maxRecordingMinutesHint">
+          Recording stops automatically after this duration to prevent leaving transcription running. Set 0 for unlimited.
+        </div>
+      </div>
+
       <div class="security-options accent-green">
         <div class="security-options-title">📎 <span data-i18n="config.options.enhancedContextTitle">Enhanced Context</span></div>
         <div class="checkbox-group">

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,6 +45,7 @@ export default [
         HistoryBackupService: 'readonly',
         HistoryListService: 'readonly',
         DiagnosticsService: 'readonly',
+        RecordingDurationLimitService: 'readonly',
         STTProviders: 'writable',
         PCMStreamProcessor: 'writable',
         DeepgramWSProvider: 'writable',

--- a/index.html
+++ b/index.html
@@ -736,6 +736,7 @@
   <script src="js/services/meeting-context-service.js" defer></script>
   <script src="js/services/active-meeting-draft-service.js" defer></script>
   <script src="js/services/transcription-queue-overflow-service.js" defer></script>
+  <script src="js/services/recording-duration-limit-service.js" defer></script>
   <script src="js/services/fetch-retry-service.js" defer></script>
   <script src="js/services/export-service.js" defer></script>
   <script src="js/services/history-backup-service.js" defer></script>

--- a/js/app.js
+++ b/js/app.js
@@ -37,6 +37,9 @@ let isMeetingMode = false;
 let recordingStartTime = null;
 let meetingModeTimerId = null;
 
+// 最大録音時間の自動停止（切り忘れによるSTT課金の垂れ流し防止）
+let recordingLimitTimerId = null;
+
 const MEETING_TITLE_STORE = (typeof MeetingTitleStore !== 'undefined') ? MeetingTitleStore : null;
 const MEETING_CONTEXT_STORE = (typeof MeetingContextStore !== 'undefined') ? MeetingContextStore : null;
 
@@ -208,6 +211,8 @@ const AppState = {
   set recordingStartTime(value) { recordingStartTime = value; },
   get meetingModeTimerId() { return meetingModeTimerId; },
   set meetingModeTimerId(value) { meetingModeTimerId = value; },
+  get recordingLimitTimerId() { return recordingLimitTimerId; },
+  set recordingLimitTimerId(value) { recordingLimitTimerId = value; },
   get aiWorkOrderModules() { return aiWorkOrderModules; },
   set aiWorkOrderModules(value) { aiWorkOrderModules = value; },
   get meetingContext() { return meetingContext; },
@@ -1801,6 +1806,9 @@ async function startRecording() {
     // 録音モニターを開始（Issue #18: スマホでの録音中断対策）
     startRecordingMonitor();
 
+    // 最大録音時間の監視を開始（切り忘れ防止）
+    startRecordingLimitWatch();
+
     const providerName = getProviderDisplayName(provider);
     showToast(t('toast.recording.started', { provider: providerName }), 'success');
 
@@ -2245,6 +2253,7 @@ async function cleanupRecording() {
     console.log('[Cleanup] Interval cleared');
   }
   clearRecorderRestartTimeout();
+  stopRecordingLimitWatch();
 
   // 4. PCMストリームを停止
   if (AppState.pcmStreamProcessor) {
@@ -2556,6 +2565,49 @@ function startRecordingMonitor() {
   });
 
   console.log('[Monitor] Recording monitor started');
+}
+
+/**
+ * 最大録音時間の監視を開始
+ * 切り忘れによるSTT課金の垂れ流しを防ぐため、設定した上限（既定120分、0で無制限）
+ * に達したら録音を安全停止する。一時停止中の時間は上限にカウントしない。
+ */
+function startRecordingLimitWatch() {
+  stopRecordingLimitWatch();
+  if (!window.RecordingDurationLimitService) {
+    console.warn('[RecordingLimit] RecordingDurationLimitService not available');
+    return;
+  }
+  const maxMinutes = RecordingDurationLimitService.normalizeMaxMinutes(
+    SecureStorage.getOption('maxRecordingMinutes', RecordingDurationLimitService.DEFAULT_MAX_RECORDING_MINUTES)
+  );
+  if (!RecordingDurationLimitService.isLimitEnabled(maxMinutes)) {
+    console.log('[RecordingLimit] Limit disabled (unlimited)');
+    return;
+  }
+
+  AppState.recordingLimitTimerId = setInterval(() => {
+    if (!AppState.isRecording || AppState.isStopping) return;
+    if (!RecordingDurationLimitService.shouldAutoStop(getActiveDurationMs(), maxMinutes)) return;
+
+    stopRecordingLimitWatch();
+    console.log(`[RecordingLimit] Max recording duration reached (${maxMinutes} min) - stopping safely`);
+    showToast(t('toast.recording.autoStopped', { minutes: maxMinutes }), 'warning');
+    stopRecording().catch((e) => {
+      console.error('[RecordingLimit] Auto stop failed:', e);
+    });
+  }, RecordingDurationLimitService.CHECK_INTERVAL_MS);
+  console.log(`[RecordingLimit] Watching (limit: ${maxMinutes} min)`);
+}
+
+/**
+ * 最大録音時間の監視を停止
+ */
+function stopRecordingLimitWatch() {
+  if (AppState.recordingLimitTimerId) {
+    clearInterval(AppState.recordingLimitTimerId);
+    AppState.recordingLimitTimerId = null;
+  }
 }
 
 /**

--- a/js/config.js
+++ b/js/config.js
@@ -338,6 +338,10 @@ function loadSavedSettings() {
   }
   document.getElementById('costAlertEnabled').checked = SecureStorage.getOption('costAlertEnabled', true);
   document.getElementById('costLimit').value = SecureStorage.getOption('costLimit', 100);
+  const maxRecordingMinutesEl = document.getElementById('maxRecordingMinutes');
+  if (maxRecordingMinutesEl) {
+    maxRecordingMinutesEl.value = SecureStorage.getOption('maxRecordingMinutes', 120);
+  }
   document.getElementById('llmPriority').value = SecureStorage.getOption('llmPriority', 'auto');
 
   // 強化コンテキストオプション
@@ -414,6 +418,12 @@ async function saveSettings() {
   }
   SecureStorage.setOption('costAlertEnabled', document.getElementById('costAlertEnabled').checked);
   SecureStorage.setOption('costLimit', parseInt(document.getElementById('costLimit').value) || 100);
+  const maxRecordingMinutesEl = document.getElementById('maxRecordingMinutes');
+  if (maxRecordingMinutesEl) {
+    // 0 = 無制限を許容するため || ではなく明示的に検証する
+    const rawMaxMinutes = parseInt(maxRecordingMinutesEl.value, 10);
+    SecureStorage.setOption('maxRecordingMinutes', Number.isFinite(rawMaxMinutes) && rawMaxMinutes >= 0 ? rawMaxMinutes : 120);
+  }
   SecureStorage.setOption('llmPriority', document.getElementById('llmPriority').value);
 
   // 強化コンテキストオプションを保存

--- a/js/secure-storage.js
+++ b/js/secure-storage.js
@@ -139,6 +139,7 @@ const SecureStorage = {
         persistApiKeys: this.getOption('persistApiKeys', false),
         costAlertEnabled: this.getOption('costAlertEnabled', true),
         costLimit: this.getOption('costLimit', 100),
+        maxRecordingMinutes: this.getOption('maxRecordingMinutes', 120),
         llmPriority: this.getOption('llmPriority', 'auto'),
         sttProvider: this.getOption('sttProvider', 'openai_stt'),
         sttUserDictionary: this.getOption('sttUserDictionary', ''),
@@ -183,6 +184,11 @@ const SecureStorage = {
         this.setOption('clearOnClose', data.options.clearOnClose || false);
         this.setOption('costAlertEnabled', data.options.costAlertEnabled !== undefined ? data.options.costAlertEnabled : true);
         this.setOption('costLimit', data.options.costLimit || 100);
+        // 0 = 無制限を許容するため || ではなく明示的に検証する
+        var maxRecordingMinutes = Number(data.options.maxRecordingMinutes);
+        if (Number.isFinite(maxRecordingMinutes) && maxRecordingMinutes >= 0) {
+          this.setOption('maxRecordingMinutes', Math.floor(maxRecordingMinutes));
+        }
         // llmPriority旧値マイグレーション: openai → openai_llm
         var llmPriority = data.options.llmPriority || 'auto';
         if (llmPriority === 'openai') llmPriority = 'openai_llm';
@@ -214,6 +220,7 @@ const SecureStorage = {
     localStorage.removeItem('_opt_persistApiKeys');
     localStorage.removeItem('_opt_costAlertEnabled');
     localStorage.removeItem('_opt_costLimit');
+    localStorage.removeItem('_opt_maxRecordingMinutes');
     localStorage.removeItem('_opt_llmPriority');
     localStorage.removeItem('_opt_sttProvider');
     localStorage.removeItem('_opt_sttUserDictionary');

--- a/js/services/recording-duration-limit-service.js
+++ b/js/services/recording-duration-limit-service.js
@@ -1,0 +1,43 @@
+const RecordingDurationLimitService = (function () {
+  'use strict';
+
+  // 切り忘れによるSTT課金の垂れ流しを防ぐガード（0 = 無制限）
+  const DEFAULT_MAX_RECORDING_MINUTES = 120;
+  const CHECK_INTERVAL_MS = 10000;
+
+  function normalizeMaxMinutes(value) {
+    // null/undefined/空文字は未設定として既定値に倒す（Number(null) === 0 で
+    // 無制限扱いになるのを防ぐ。0 = 無制限は明示指定のみ有効）
+    if (value === null || value === undefined || value === '') {
+      return DEFAULT_MAX_RECORDING_MINUTES;
+    }
+    const num = Number(value);
+    if (!Number.isFinite(num) || num < 0) {
+      return DEFAULT_MAX_RECORDING_MINUTES;
+    }
+    return Math.floor(num);
+  }
+
+  function isLimitEnabled(maxMinutes) {
+    return normalizeMaxMinutes(maxMinutes) > 0;
+  }
+
+  function shouldAutoStop(activeMs, maxMinutes) {
+    const limit = normalizeMaxMinutes(maxMinutes);
+    if (limit <= 0) return false;
+    if (!Number.isFinite(activeMs) || activeMs <= 0) return false;
+    return activeMs >= limit * 60000;
+  }
+
+  return {
+    DEFAULT_MAX_RECORDING_MINUTES,
+    CHECK_INTERVAL_MS,
+    normalizeMaxMinutes,
+    isLimitEnabled,
+    shouldAutoStop
+  };
+})();
+
+if (typeof window !== 'undefined') {
+  window.RecordingDurationLimitService = RecordingDurationLimitService;
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -283,6 +283,10 @@
       "costLimit": "Session cost limit (JPY)",
       "costLimitPlaceholder": "e.g. 100",
       "costAlertEnabled": "Show warning at 80% of limit",
+      "recordingLimitTitle": "Recording Limit",
+      "maxRecordingMinutes": "Max recording duration (minutes)",
+      "maxRecordingMinutesPlaceholder": "e.g. 120",
+      "maxRecordingMinutesHint": "Recording stops automatically after this duration to prevent leaving transcription running. Set 0 for unlimited.",
       "enhancedContextTitle": "Enhanced Context",
       "enhancedContextEnabled": "Enable file attachments for meeting context",
       "enhancedContextHint": "When enabled, you can attach TXT/MD/PDF/DOCX/CSV files to provide additional meeting materials to AI."
@@ -330,6 +334,7 @@
       "paused": "Recording paused",
       "resumed": "Recording resumed",
       "stopped": "Recording stopped",
+      "autoStopped": "Recording stopped automatically after reaching the {minutes}-minute limit",
       "interrupted": "Recording interrupted. Content saved. Press record button to continue"
     },
     "copy": {

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -283,6 +283,10 @@
       "costLimit": "1セッションの上限金額（円）",
       "costLimitPlaceholder": "例: 100",
       "costAlertEnabled": "上限の80%で警告を表示",
+      "recordingLimitTitle": "録音時間の上限",
+      "maxRecordingMinutes": "最大録音時間（分）",
+      "maxRecordingMinutesPlaceholder": "例: 120",
+      "maxRecordingMinutesHint": "切り忘れによる文字起こしの垂れ流しを防ぐため、設定時間に達すると録音を自動停止します。0で無制限。",
       "enhancedContextTitle": "強化コンテキスト",
       "enhancedContextEnabled": "ファイル添付による会議資料の提供を有効化",
       "enhancedContextHint": "有効にすると、TXT/MD/PDF/DOCX/CSVファイルを添付してAIに追加の会議資料を提供できます。"
@@ -330,6 +334,7 @@
       "paused": "録音を一時停止しました",
       "resumed": "録音を再開しました",
       "stopped": "録音を停止しました",
+      "autoStopped": "最大録音時間（{minutes}分）に達したため、録音を自動停止しました",
       "interrupted": "録音が中断されました。ここまでの内容は保存されています。録音ボタンで再開できます"
     },
     "copy": {

--- a/tests/unit/recording-duration-limit-service.test.mjs
+++ b/tests/unit/recording-duration-limit-service.test.mjs
@@ -1,0 +1,56 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadScript } from '../helpers/load-script.mjs';
+
+function loadService() {
+  return loadScript('js/services/recording-duration-limit-service.js')
+    .RecordingDurationLimitService;
+}
+
+describe('RecordingDurationLimitService', () => {
+  it('normalizes invalid limits to the default (120 minutes)', () => {
+    const service = loadService();
+    assert.equal(service.DEFAULT_MAX_RECORDING_MINUTES, 120);
+    assert.equal(service.normalizeMaxMinutes(undefined), 120);
+    assert.equal(service.normalizeMaxMinutes(null), 120);
+    assert.equal(service.normalizeMaxMinutes(NaN), 120);
+    assert.equal(service.normalizeMaxMinutes(-5), 120);
+    assert.equal(service.normalizeMaxMinutes('abc'), 120);
+  });
+
+  it('keeps valid limits including 0 (unlimited) and floors fractions', () => {
+    const service = loadService();
+    assert.equal(service.normalizeMaxMinutes(0), 0);
+    assert.equal(service.normalizeMaxMinutes(90), 90);
+    assert.equal(service.normalizeMaxMinutes('60'), 60);
+    assert.equal(service.normalizeMaxMinutes(45.9), 45);
+  });
+
+  it('treats 0 as disabled and positive limits as enabled', () => {
+    const service = loadService();
+    assert.equal(service.isLimitEnabled(0), false);
+    assert.equal(service.isLimitEnabled(120), true);
+    // invalid values fall back to the default limit, so the guard stays on
+    assert.equal(service.isLimitEnabled(undefined), true);
+  });
+
+  it('auto-stops only when active duration reaches the limit', () => {
+    const service = loadService();
+    const twoHoursMs = 120 * 60000;
+    assert.equal(service.shouldAutoStop(twoHoursMs - 1, 120), false);
+    assert.equal(service.shouldAutoStop(twoHoursMs, 120), true);
+    assert.equal(service.shouldAutoStop(twoHoursMs + 60000, 120), true);
+  });
+
+  it('never auto-stops when the limit is 0 (unlimited)', () => {
+    const service = loadService();
+    assert.equal(service.shouldAutoStop(Number.MAX_SAFE_INTEGER, 0), false);
+  });
+
+  it('ignores invalid active durations', () => {
+    const service = loadService();
+    assert.equal(service.shouldAutoStop(NaN, 120), false);
+    assert.equal(service.shouldAutoStop(undefined, 120), false);
+    assert.equal(service.shouldAutoStop(0, 120), false);
+  });
+});


### PR DESCRIPTION
## 概要
録音の切り忘れによるSTT課金の垂れ流し（特にDeepgramストリーミング）を防ぐため、録音の最大時間を設定可能にし、上限到達で自動的に安全停止する。

Closes #172 / Refs #158

## 変更内容
- **js/services/recording-duration-limit-service.js**（新規）: 上限判定の純粋ロジック（DOM非依存、unit test付き）
- **js/app.js**: 録音開始時に10秒間隔の監視を開始、`getActiveDurationMs()` が上限到達で `stopRecording()` を呼び安全停止＋警告トースト。`cleanupRecording()` で監視を確実に解除
- **config.html / js/config.js**: 設定画面に「録音時間の上限」欄を追加（既定120分、0で無制限。0を許容するため `|| 100` パターンは使わず明示検証）
- **js/secure-storage.js**: `maxRecordingMinutes` を exportAll / importAll / clearAll に追加
- **locales/ja.json / en.json**: 設定ラベル・ヒント・自動停止トーストのキーを追加
- **eslint.config.mjs**: 新サービスのグローバル登録

## 設計メモ
- 一時停止中の時間は上限にカウントしない（`getActiveDurationMs()` がpause時間を控除）
- `Number(null) === 0` で未設定が「無制限」に化けるのを防ぐため、null/undefined/空文字は既定値120分に倒す（unit testで担保）
- 停止は既存の `stopRecording()` フローをそのまま使用（履歴スナップショット保存を含む）

## 検証
- unit: 232件 pass（新規6件含む）/ fail 0
- eslint: 0 errors / prettier: 新規ファイルはformat済み
- test:i18n: ja/en 496キー同期OK
- test:ui-smoke / test:config-smoke / test:e2e: すべてpass

🤖 Generated with [Claude Code](https://claude.com/claude-code)