### PR TITLE
feat: allow API key persistence in mobile PWA

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,6 +1,6 @@
 # セキュリティ / Security
 
-最終更新日 / Last Updated: 2026-02-10
+最終更新日 / Last Updated: 2026-07-11
 
 ---
 
@@ -31,7 +31,8 @@
 
 ### APIキーの扱い
 - APIキーは既定でセッション内のみ保持され、タブ/ブラウザを閉じると消えます
-- デスクトップアプリ（Chrome/Edgeアプリ）のみ、設定で任意に端末保存を有効化できます（非推奨）
+- インストールしたアプリ表示（ホーム画面に追加したモバイルPWA、Chrome/Edgeデスクトップアプリ）のみ、設定で任意に端末保存を有効化できます（非推奨）
+- 記憶を有効にするとAPIキーは端末のlocalStorageに平文で残ります。共有端末では使用せず、端末の紛失・盗難に備えて画面ロックを有効にしてください
 - 開発者のサーバーに送信されることはありません
 - HTTPS通信のみを使用します
 
@@ -59,7 +60,7 @@
 - APIキーはWeb Storage（既定はsessionStorage、記憶ON設定時はlocalStorage）に**平文**で保存されます。暗号化は行っていません
 - 同一オリジンで実行されるスクリプト（本アプリ自身のバグやXSS）はWeb Storageを読み取れます。この対策として、厳格なCSPと一貫したエスケープ処理によりXSSの混入自体を防ぐ設計としています
 - sessionStorageは既定でタブ/ブラウザを閉じると消去され、平文データが残る期間を限定します
-- 記憶（persistApiKeys）オプションはユーザーの明示的なオプトインが必要で、対応環境（デスクトップアプリ表示モードなど）に限定してのみ有効化されます
+- 記憶（persistApiKeys）オプションはユーザーの明示的なオプトインが必要で、対応環境（ホーム画面に追加したモバイルPWAまたはデスクトップアプリ表示モード）に限定してのみ有効化されます。モバイルの通常ブラウザタブでは有効化できません
 - WebCrypto等によるクライアントサイド暗号化は検討しましたが、復号鍵も同一オリジンのJavaScriptから参照可能である以上、アプリ自身のオリジンを起点とする攻撃（XSS等）に対しては保護効果がないため、実装を見送りました
 - Web Storageへの書き込み（`localStorage.setItem`等）はストレージ容量超過やSafariプライベートモード等で例外を投げる場合があります。本アプリはこれらの例外を捕捉し、保存に失敗してもアプリの動作は継続する設計です（データは保存されない場合があります）
 
@@ -92,7 +93,8 @@ The Application is designed to minimize security risks.
 
 ### Handling of API Keys
 - API keys are session-only by default and cleared when the tab/browser closes
-- Desktop app mode (Chrome/Edge app) can optionally persist API keys on device via explicit user opt-in (not recommended)
+- Installed app mode (a mobile PWA added to the home screen or a Chrome/Edge desktop app) can optionally persist API keys on device via explicit user opt-in (not recommended)
+- Persisted API keys remain unencrypted in localStorage. Do not enable this on shared devices, and use a device screen lock to reduce the risk from loss or theft
 - They are never transmitted to developer-controlled servers
 - All communication uses HTTPS
 

--- a/js/secure-storage.js
+++ b/js/secure-storage.js
@@ -28,9 +28,6 @@ const SecureStorage = {
   isPersistentApiKeysSupported: function() {
     if (typeof window === 'undefined' || typeof navigator === 'undefined') return false;
     if (typeof window.matchMedia !== 'function') return false;
-    const userAgent = navigator.userAgent || '';
-    const isMobile = /Android|iPhone|iPad|iPod/i.test(userAgent);
-    if (isMobile) return false;
     return (
       window.matchMedia('(display-mode: standalone)').matches ||
       window.matchMedia('(display-mode: window-controls-overlay)').matches

--- a/locales/en.json
+++ b/locales/en.json
@@ -188,8 +188,8 @@
     "closeTabHint": "Could not close automatically due to browser restrictions. Please close this tab manually.",
     "security": {
       "title": "API Key Security",
-      "description": "API keys are session-only by default and are cleared when the tab/browser closes. Desktop app mode can optionally remember keys. They are never sent to external servers.",
-      "encrypted": "Default: session-only storage (desktop app can optionally persist)",
+      "description": "API keys are session-only by default and are cleared when the tab/browser closes. Installed app mode can optionally remember keys. They are never sent to external servers.",
+      "encrypted": "Default: session-only storage (installed app mode can optionally persist)",
       "httpsOnly": "Only sent via HTTPS during API calls",
       "isolated": "Inaccessible from other websites",
       "exportable": "Import/export settings supported (API keys excluded)",
@@ -199,8 +199,8 @@
     "storage": {
       "persistLabel": "API keys are session-only (cannot be persisted in browser mode)",
       "persistWarning": "Keys are cleared when the tab/browser closes. Export does not include API keys.",
-      "persistLabelEnabled": "Remember API keys on this desktop app (not recommended)",
-      "persistWarningEnabled": "API keys are saved to localStorage on this device. Keep this OFF on shared devices. Export does not include API keys."
+      "persistLabelEnabled": "Remember API keys in this app (not recommended)",
+      "persistWarningEnabled": "API keys are stored unencrypted in localStorage on this device. Keep this OFF on shared devices. Keys may be exposed if the device is lost or stolen. Export does not include API keys."
     },
     "stt": {
       "clickToExpand": "Click to expand settings",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -188,8 +188,8 @@
     "closeTabHint": "ブラウザの制限により自動で閉じられませんでした。手動でタブを閉じてください。",
     "security": {
       "title": "APIキーのセキュリティ",
-      "description": "APIキーは既定でセッション内のみ保持され、タブ/ブラウザを閉じると消えます。デスクトップアプリでは任意で記憶を有効化できます。外部サーバーには一切送信されません。",
-      "encrypted": "既定はセッション保持（デスクトップアプリのみ任意で記憶可）",
+      "description": "APIキーは既定でセッション内のみ保持され、タブ/ブラウザを閉じると消えます。インストールしたアプリでは任意で記憶を有効化できます。外部サーバーには一切送信されません。",
+      "encrypted": "既定はセッション保持（インストールしたアプリのみ任意で記憶可）",
       "httpsOnly": "API呼び出し時のみHTTPS経由で送信",
       "isolated": "他のWebサイトからはアクセス不可",
       "exportable": "設定のエクスポート/インポート対応（APIキー除外）",
@@ -199,8 +199,8 @@
     "storage": {
       "persistLabel": "APIキーはセッション限定（ブラウザ版では保持不可）",
       "persistWarning": "タブ/ブラウザを閉じると消えます。エクスポートにAPIキーは含まれません。",
-      "persistLabelEnabled": "このデスクトップアプリでAPIキーを記憶する（非推奨）",
-      "persistWarningEnabled": "APIキーはこの端末のlocalStorageに保存されます。共有端末ではOFFを推奨します。エクスポートにAPIキーは含まれません。"
+      "persistLabelEnabled": "このアプリでAPIキーを記憶する（非推奨）",
+      "persistWarningEnabled": "APIキーはこの端末のlocalStorageに平文で保存されます。共有端末ではOFFにしてください。端末の紛失・盗難時に漏洩する可能性があります。エクスポートにAPIキーは含まれません。"
     },
     "stt": {
       "clickToExpand": "クリックで設定を展開",

--- a/tests/unit/secure-storage.test.mjs
+++ b/tests/unit/secure-storage.test.mjs
@@ -69,16 +69,51 @@ describe('SecureStorage persistApiKeys policy', () => {
     assert.equal(localStorage.getItem('_ak_openai'), null);
   });
 
-  it('stores keys in localStorage when persistApiKeys is enabled in desktop app mode', () => {
+  it('supports persistence in a mobile standalone PWA', () => {
     const { SecureStorage, localStorage, sessionStorage } = createSecureStorageContext({
-      isStandalone: true
+      isStandalone: true,
+      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_7_9 like Mac OS X)'
     });
+
+    assert.equal(SecureStorage.isPersistentApiKeysSupported(), true);
+
+    SecureStorage.setPersistApiKeys(true);
+    SecureStorage.setApiKey('deepgram', 'persisted-key');
+
+    assert.equal(localStorage.getItem('_ak_deepgram'), 'persisted-key');
+    assert.equal(sessionStorage.getItem('_ak_deepgram'), null);
+  });
+
+  it('does not support persistence in a mobile browser tab', () => {
+    const { SecureStorage } = createSecureStorageContext({
+      userAgent: 'Mozilla/5.0 (Linux; Android 15; Pixel 9) AppleWebKit/537.36'
+    });
+
+    assert.equal(SecureStorage.isPersistentApiKeysSupported(), false);
+  });
+
+  it('keeps desktop standalone persistence behavior unchanged', () => {
+    const { SecureStorage, localStorage, sessionStorage } = createSecureStorageContext({
+      isStandalone: true,
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0)'
+    });
+
+    assert.equal(SecureStorage.isPersistentApiKeysSupported(), true);
 
     SecureStorage.setPersistApiKeys(true);
     SecureStorage.setApiKey('openai', 'persisted-key');
 
     assert.equal(localStorage.getItem('_ak_openai'), 'persisted-key');
     assert.equal(sessionStorage.getItem('_ak_openai'), null);
+  });
+
+  it('keeps desktop window-controls-overlay persistence behavior unchanged', () => {
+    const { SecureStorage } = createSecureStorageContext({
+      isWindowControlsOverlay: true,
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    });
+
+    assert.equal(SecureStorage.isPersistentApiKeysSupported(), true);
   });
 
   it('keeps preference but disables effective persistApiKeys on non-standalone browser tabs', () => {
@@ -102,24 +137,17 @@ describe('SecureStorage persistApiKeys policy', () => {
     assert.equal(SecureStorage.getApiKey('openai'), '');
   });
 
-  it('rejects persistent key mode on mobile user agents', () => {
-    const { SecureStorage } = createSecureStorageContext({
-      isStandalone: true,
-      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)'
-    });
-
-    assert.equal(SecureStorage.isPersistentApiKeysSupported(), false);
-  });
-
   it('includes persistApiKeys option in export payload', () => {
     const { SecureStorage } = createSecureStorageContext({
       isStandalone: true
     });
 
     SecureStorage.setPersistApiKeys(true);
+    SecureStorage.setApiKey('deepgram', 'must-not-be-exported');
     const exported = SecureStorage.exportAll();
 
     assert.equal(exported.options.persistApiKeys, true);
+    assert.equal(JSON.stringify(exported).includes('must-not-be-exported'), false);
   });
 });
 


### PR DESCRIPTION
## Summary

- allow API key persistence when a mobile PWA is running in standalone display mode
- keep persistence disabled for normal mobile browser tabs and OFF by default
- update Japanese and English security copy for mobile PWA support and device-loss risk
- add policy tests for mobile standalone, mobile browser, desktop standalone, desktop window-controls-overlay, and API-key export exclusion

## Why

Mobile user agents were rejected before display-mode checks, so an iPhone PWA installed to the home screen could never opt in to persistent API-key storage. The capability check now relies on installed-app display modes instead of device type.

## Validation

- `npm run test:unit` (234 passed)
- `npx eslint .`
- `npm run test:i18n`
- `npm run test:config-smoke`
- `git diff --check`

Closes #174
Refs #158

## Human acceptance check

On an iPhone home-screen PWA, enable API-key persistence, fully close the PWA, reopen it, and confirm the key remains available. Confirm the option stays disabled in a normal Safari tab.
