### PR TITLE
fix(storage): iOSホーム画面PWAの判定に navigator.standalone を追加

### DIFF
--- a/js/secure-storage.js
+++ b/js/secure-storage.js
@@ -27,6 +27,10 @@ const SecureStorage = {
 
   isPersistentApiKeysSupported: function() {
     if (typeof window === 'undefined' || typeof navigator === 'undefined') return false;
+    // iOSのホーム画面Web Appは display-mode メディアクエリに一致しない場合がある
+    // （iPhone XR / iOS 18.7 実機で確認）。iOS標準の navigator.standalone を先に見る。
+    // Safariの通常タブでは false、iOS以外では undefined になるため誤判定しない。
+    if (navigator.standalone === true) return true;
     if (typeof window.matchMedia !== 'function') return false;
     return (
       window.matchMedia('(display-mode: standalone)').matches ||

--- a/tests/unit/secure-storage.test.mjs
+++ b/tests/unit/secure-storage.test.mjs
@@ -27,6 +27,9 @@ function createSecureStorageContext({
   isStandalone = false,
   isWindowControlsOverlay = false,
   userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0)',
+  // iOS Safariのみ存在するプロパティ。ホーム画面Web Appで true、通常タブで false、
+  // iOS以外では undefined（= プロパティ自体なし）を再現する
+  iosNavigatorStandalone = undefined,
   localData = {},
   sessionData = {},
   localThrowsOnSetItem = false,
@@ -46,6 +49,9 @@ function createSecureStorageContext({
     }
   };
   const navigator = { userAgent };
+  if (iosNavigatorStandalone !== undefined) {
+    navigator.standalone = iosNavigatorStandalone;
+  }
 
   const { SecureStorage } = loadScript('js/secure-storage.js', {
     window,
@@ -82,6 +88,32 @@ describe('SecureStorage persistApiKeys policy', () => {
 
     assert.equal(localStorage.getItem('_ak_deepgram'), 'persisted-key');
     assert.equal(sessionStorage.getItem('_ak_deepgram'), null);
+  });
+
+  it('supports persistence in an iOS home-screen web app even when display-mode does not match', () => {
+    // iPhone XR / iOS 18.7 実機: display-mode: standalone に一致しないが navigator.standalone は true
+    const { SecureStorage, localStorage, sessionStorage } = createSecureStorageContext({
+      isStandalone: false,
+      iosNavigatorStandalone: true,
+      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_7_9 like Mac OS X)'
+    });
+
+    assert.equal(SecureStorage.isPersistentApiKeysSupported(), true);
+
+    SecureStorage.setPersistApiKeys(true);
+    SecureStorage.setApiKey('deepgram', 'persisted-key');
+
+    assert.equal(localStorage.getItem('_ak_deepgram'), 'persisted-key');
+    assert.equal(sessionStorage.getItem('_ak_deepgram'), null);
+  });
+
+  it('does not support persistence in an iOS Safari browser tab', () => {
+    const { SecureStorage } = createSecureStorageContext({
+      iosNavigatorStandalone: false,
+      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_7_9 like Mac OS X)'
+    });
+
+    assert.equal(SecureStorage.isPersistentApiKeysSupported(), false);
   });
 
   it('does not support persistence in a mobile browser tab', () => {


### PR DESCRIPTION
## 概要
PR #175 のiPhone XR (iOS 18.7.9) 実機受入で、ホーム画面PWAなのに設定画面のAPIキー記憶オプトインが有効化されない（「セッション限定」表示のまま）問題の修正。

Closes #174

## 原因
iOSのホーム画面Web Appは `matchMedia('(display-mode: standalone)')` に一致しない場合がある（実機で確認）。現在の `isPersistentApiKeysSupported()` は display-mode メディアクエリのみを見ているため、iOSで永続保存が常に「非対応」と判定される。

## 修正
iOS標準の判定シグナル `navigator.standalone === true` を display-mode チェックの前に追加（+4行）。
- iOSホーム画面Web App: `navigator.standalone === true` → 対応
- iOS Safari通常タブ: `navigator.standalone === false` → 従来どおり非対応
- iOS以外: プロパティ自体が `undefined` → 既存の display-mode 判定にそのままフォールスルー（挙動不変）

## テスト
- 追加: iOSホーム画面Web App（display-mode不一致 + standalone=true）で対応判定＋localStorage保存 / iOS Safariタブで非対応判定 の2件
- unit 236件 pass / eslint 0 errors / config-smoke / ui-smoke pass

## 受入確認（HUMAN・merge後）
iPhone XRのPWAで: 設定画面に「このアプリでAPIキーを記憶する（非推奨）」が有効表示 → ON＋キー入力で保存 → アプリ完全終了 → 再起動でキー保持

🤖 Generated with [Claude Code](https://claude.com/claude-code)