### PR TITLE
refactor: extract recorder lifecycle state machine

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,6 +40,7 @@ export default [
         LLMClientService: 'readonly',
         MeetingContextService: 'readonly',
         TranscriptionQueueOverflowService: 'readonly',
+        RecorderLifecycleService: 'readonly',
         FetchRetryService: 'readonly',
         ExportService: 'readonly',
         HistoryBackupService: 'readonly',

--- a/index.html
+++ b/index.html
@@ -736,6 +736,7 @@
   <script src="js/services/meeting-context-service.js" defer></script>
   <script src="js/services/active-meeting-draft-service.js" defer></script>
   <script src="js/services/transcription-queue-overflow-service.js" defer></script>
+  <script src="js/services/recorder-lifecycle-service.js" defer></script>
   <script src="js/services/recording-duration-limit-service.js" defer></script>
   <script src="js/services/fetch-retry-service.js" defer></script>
   <script src="js/services/export-service.js" defer></script>

--- a/js/app.js
+++ b/js/app.js
@@ -1,8 +1,6 @@
 // =====================================
 // グローバル変数
 // =====================================
-let isRecording = false;
-let isPaused = false;
 let pausedTotalMs = 0;
 let pauseStartedAt = null;
 let mediaRecorder = null;
@@ -20,7 +18,6 @@ const TRANSCRIPT_RENDER_CAP = 200;
 let transcriptRenderPending = false;
 
 // 停止時のレース防止用
-let isStopping = false;
 let finalStopPromise = null;
 let finalStopResolve = null;
 let recorderStopReason = null;
@@ -39,6 +36,8 @@ let meetingModeTimerId = null;
 
 // 最大録音時間の自動停止（切り忘れによるSTT課金の垂れ流し防止）
 let recordingLimitTimerId = null;
+
+const recorderLifecycle = RecorderLifecycleService.create();
 
 const MEETING_TITLE_STORE = (typeof MeetingTitleStore !== 'undefined') ? MeetingTitleStore : null;
 const MEETING_CONTEXT_STORE = (typeof MeetingContextStore !== 'undefined') ? MeetingContextStore : null;
@@ -159,10 +158,9 @@ let transcriptionQueueOverflow = TranscriptionQueueOverflowService.createInitial
 
 // App-wide state aggregate (Issue #131)
 const AppState = {
-  get isRecording() { return isRecording; },
-  set isRecording(value) { isRecording = value; },
-  get isPaused() { return isPaused; },
-  set isPaused(value) { isPaused = value; },
+  get recorderLifecycleState() { return recorderLifecycle.getState(); },
+  get isRecording() { return recorderLifecycle.isRecording(); },
+  get isPaused() { return recorderLifecycle.isPaused(); },
   get pausedTotalMs() { return pausedTotalMs; },
   set pausedTotalMs(value) { pausedTotalMs = value; },
   get pauseStartedAt() { return pauseStartedAt; },
@@ -183,8 +181,7 @@ const AppState = {
   set meetingStartMarkerId(value) { meetingStartMarkerId = value; },
   get transcriptRenderPending() { return transcriptRenderPending; },
   set transcriptRenderPending(value) { transcriptRenderPending = value; },
-  get isStopping() { return isStopping; },
-  set isStopping(value) { isStopping = value; },
+  get isStopping() { return recorderLifecycle.isStopping(); },
   get finalStopPromise() { return finalStopPromise; },
   set finalStopPromise(value) { finalStopPromise = value; },
   get finalStopResolve() { return finalStopResolve; },
@@ -1776,7 +1773,6 @@ async function startRecording() {
     return;
   }
 
-  AppState.isPaused = false;
   AppState.pausedTotalMs = 0;
   AppState.pauseStartedAt = null;
   AppState.recorderStopReason = null;
@@ -1786,6 +1782,7 @@ async function startRecording() {
 
   // 一時取得したストリームをcurrentAudioStreamに引き継ぐ
   AppState.currentAudioStream = tempAudioStream;
+  recorderLifecycle.transition(RecorderLifecycleService.EVENTS.PREPARE);
 
   try {
     // プロバイダータイプに応じて録音を開始
@@ -1795,7 +1792,7 @@ async function startRecording() {
       await startChunkedRecording(provider);
     }
 
-    AppState.isRecording = true;
+    recorderLifecycle.transition(RecorderLifecycleService.EVENTS.START);
     updateUI();
     syncMinutesButtonState(); // PR-3: 議事録ボタン無効化
     beginActiveMeetingDraft();
@@ -2240,10 +2237,9 @@ async function cleanupRecording() {
   stopRecordingMonitor();
 
   // 1. 停止フラグをオンにする（onstopで最終blobを処理するため）
-  AppState.isStopping = true;
+  recorderLifecycle.transition(RecorderLifecycleService.EVENTS.STOP);
 
-  // 2. 録音フラグをオフにして新しいblobの生成を止める
-  AppState.isRecording = false;
+  // 2. stopping状態にして新しいblobの生成を止める
   syncMinutesButtonState(); // PR-3: 議事録ボタン有効化
 
   // 3. インターバルをクリア（stop→restart の繰り返しを止める）
@@ -2295,7 +2291,7 @@ async function cleanupRecording() {
 
   // 9. MediaRecorderの参照破棄は最後
   AppState.mediaRecorder = null;
-  AppState.isStopping = false;
+  recorderLifecycle.transition(RecorderLifecycleService.EVENTS.FINISH);
   AppState.recorderStopReason = null;
   AppState.activeProviderId = null;
 
@@ -2398,7 +2394,10 @@ async function stopRecording() {
     AppState.pausedTotalMs += Date.now() - AppState.pauseStartedAt;
     AppState.pauseStartedAt = null;
   }
-  AppState.isPaused = false;
+  if (AppState.isPaused) {
+    // 既存どおり、停止処理に入る前に一時停止状態を解除する。
+    recorderLifecycle.transition(RecorderLifecycleService.EVENTS.RESUME);
+  }
   AppState.recorderStopReason = 'stop';
   clearRecorderRestartTimeout();
 
@@ -2427,7 +2426,7 @@ async function pauseRecording() {
   console.log('=== pauseRecording ===');
   if (!AppState.isRecording || AppState.isPaused) return;
 
-  AppState.isPaused = true;
+  recorderLifecycle.transition(RecorderLifecycleService.EVENTS.PAUSE);
   AppState.pauseStartedAt = Date.now();
   AppState.recorderStopReason = 'pause';
   clearRecorderRestartTimeout();
@@ -2471,7 +2470,7 @@ async function resumeRecording() {
     AppState.pausedTotalMs += resumedAt - AppState.pauseStartedAt;
   }
   AppState.pauseStartedAt = null;
-  AppState.isPaused = false;
+  recorderLifecycle.transition(RecorderLifecycleService.EVENTS.RESUME);
   AppState.recorderStopReason = null;
 
   try {
@@ -2491,7 +2490,7 @@ async function resumeRecording() {
     }
   } catch (e) {
     console.error('[Resume] Failed:', e);
-    AppState.isPaused = true;
+    recorderLifecycle.transition(RecorderLifecycleService.EVENTS.PAUSE);
     AppState.pauseStartedAt = Date.now();
     updateUI();
     showToast(t('error.recording', { message: e.message }), 'error');

--- a/js/services/recorder-lifecycle-service.js
+++ b/js/services/recorder-lifecycle-service.js
@@ -1,0 +1,129 @@
+const RecorderLifecycleService = (function () {
+  'use strict';
+
+  const STATES = Object.freeze({
+    IDLE: 'idle',
+    PREPARING: 'preparing',
+    RECORDING: 'recording',
+    PAUSED: 'paused',
+    SUSPENDED: 'suspended',
+    RESUMING: 'resuming',
+    STOPPING: 'stopping'
+  });
+
+  const EVENTS = Object.freeze({
+    PREPARE: 'prepare',
+    START: 'start',
+    PAUSE: 'pause',
+    RESUME: 'resume',
+    SUSPEND: 'suspend',
+    RESUME_COMPLETE: 'resume_complete',
+    STOP: 'stop',
+    FINISH: 'finish',
+    CANCEL: 'cancel'
+  });
+
+  const TRANSITIONS = Object.freeze({
+    [STATES.IDLE]: Object.freeze({
+      [EVENTS.PREPARE]: STATES.PREPARING
+    }),
+    [STATES.PREPARING]: Object.freeze({
+      [EVENTS.START]: STATES.RECORDING,
+      [EVENTS.STOP]: STATES.STOPPING,
+      [EVENTS.CANCEL]: STATES.IDLE
+    }),
+    [STATES.RECORDING]: Object.freeze({
+      [EVENTS.PAUSE]: STATES.PAUSED,
+      [EVENTS.SUSPEND]: STATES.SUSPENDED,
+      [EVENTS.STOP]: STATES.STOPPING
+    }),
+    [STATES.PAUSED]: Object.freeze({
+      [EVENTS.RESUME]: STATES.RECORDING,
+      [EVENTS.SUSPEND]: STATES.SUSPENDED,
+      [EVENTS.STOP]: STATES.STOPPING
+    }),
+    [STATES.SUSPENDED]: Object.freeze({
+      [EVENTS.RESUME]: STATES.RESUMING,
+      [EVENTS.STOP]: STATES.STOPPING
+    }),
+    [STATES.RESUMING]: Object.freeze({
+      [EVENTS.RESUME_COMPLETE]: STATES.RECORDING,
+      [EVENTS.SUSPEND]: STATES.SUSPENDED,
+      [EVENTS.STOP]: STATES.STOPPING
+    }),
+    [STATES.STOPPING]: Object.freeze({
+      [EVENTS.FINISH]: STATES.IDLE
+    })
+  });
+
+  const ACTIVE_RECORDING_STATES = new Set([
+    STATES.RECORDING,
+    STATES.PAUSED,
+    STATES.SUSPENDED,
+    STATES.RESUMING
+  ]);
+
+  function create() {
+    let state = STATES.IDLE;
+    const listeners = new Set();
+
+    function getState() {
+      return state;
+    }
+
+    function transition(event) {
+      const previousState = state;
+      const nextState = TRANSITIONS[previousState]?.[event];
+      if (!nextState) {
+        console.warn(`[RecorderLifecycle] Rejected transition: ${previousState} --${event}--> ?`);
+        return false;
+      }
+
+      state = nextState;
+      listeners.forEach(listener => listener(nextState, previousState, event));
+      return true;
+    }
+
+    function onStateChange(callback) {
+      if (typeof callback !== 'function') {
+        console.warn('[RecorderLifecycle] State change listener must be a function');
+        return function () {};
+      }
+      listeners.add(callback);
+      return function unsubscribe() {
+        listeners.delete(callback);
+      };
+    }
+
+    function isRecording() {
+      return ACTIVE_RECORDING_STATES.has(state);
+    }
+
+    function isPaused() {
+      return state === STATES.PAUSED;
+    }
+
+    function isStopping() {
+      return state === STATES.STOPPING;
+    }
+
+    return Object.freeze({
+      getState,
+      transition,
+      onStateChange,
+      isRecording,
+      isPaused,
+      isStopping
+    });
+  }
+
+  return Object.freeze({
+    STATES,
+    EVENTS,
+    create
+  });
+})();
+
+if (typeof window !== 'undefined') {
+  window.RecorderLifecycleService = RecorderLifecycleService;
+}

--- a/tests/unit/recorder-lifecycle-service.test.mjs
+++ b/tests/unit/recorder-lifecycle-service.test.mjs
@@ -1,0 +1,126 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadScript } from '../helpers/load-script.mjs';
+
+function loadService(consoleOverride = console) {
+  return loadScript('js/services/recorder-lifecycle-service.js', {
+    console: consoleOverride
+  }).RecorderLifecycleService;
+}
+
+describe('RecorderLifecycleService', () => {
+  it('moves through recording, pause, resume, and stop states', () => {
+    const service = loadService();
+    const lifecycle = service.create();
+
+    assert.equal(lifecycle.getState(), service.STATES.IDLE);
+    assert.equal(lifecycle.transition(service.EVENTS.PREPARE), true);
+    assert.equal(lifecycle.getState(), service.STATES.PREPARING);
+    assert.equal(lifecycle.transition(service.EVENTS.START), true);
+    assert.equal(lifecycle.getState(), service.STATES.RECORDING);
+    assert.equal(lifecycle.transition(service.EVENTS.PAUSE), true);
+    assert.equal(lifecycle.getState(), service.STATES.PAUSED);
+    assert.equal(lifecycle.transition(service.EVENTS.RESUME), true);
+    assert.equal(lifecycle.getState(), service.STATES.RECORDING);
+    assert.equal(lifecycle.transition(service.EVENTS.STOP), true);
+    assert.equal(lifecycle.getState(), service.STATES.STOPPING);
+    assert.equal(lifecycle.transition(service.EVENTS.FINISH), true);
+    assert.equal(lifecycle.getState(), service.STATES.IDLE);
+  });
+
+  it('defines the suspended and resuming path for the next implementation phase', () => {
+    const service = loadService();
+    const lifecycle = service.create();
+
+    lifecycle.transition(service.EVENTS.PREPARE);
+    lifecycle.transition(service.EVENTS.START);
+    lifecycle.transition(service.EVENTS.SUSPEND);
+    assert.equal(lifecycle.getState(), service.STATES.SUSPENDED);
+
+    lifecycle.transition(service.EVENTS.RESUME);
+    assert.equal(lifecycle.getState(), service.STATES.RESUMING);
+
+    lifecycle.transition(service.EVENTS.RESUME_COMPLETE);
+    assert.equal(lifecycle.getState(), service.STATES.RECORDING);
+  });
+
+  it('can return from resuming to suspended when recovery is interrupted', () => {
+    const service = loadService();
+    const lifecycle = service.create();
+
+    lifecycle.transition(service.EVENTS.PREPARE);
+    lifecycle.transition(service.EVENTS.START);
+    lifecycle.transition(service.EVENTS.SUSPEND);
+    lifecycle.transition(service.EVENTS.RESUME);
+    lifecycle.transition(service.EVENTS.SUSPEND);
+
+    assert.equal(lifecycle.getState(), service.STATES.SUSPENDED);
+  });
+
+  it('can cancel preparation without entering a recording state', () => {
+    const service = loadService();
+    const lifecycle = service.create();
+
+    lifecycle.transition(service.EVENTS.PREPARE);
+    assert.equal(lifecycle.transition(service.EVENTS.CANCEL), true);
+    assert.equal(lifecycle.getState(), service.STATES.IDLE);
+  });
+
+  it('derives legacy recording flags from the lifecycle state', () => {
+    const service = loadService();
+    const lifecycle = service.create();
+
+    assert.equal(lifecycle.isRecording(), false);
+    assert.equal(lifecycle.isPaused(), false);
+    assert.equal(lifecycle.isStopping(), false);
+
+    lifecycle.transition(service.EVENTS.PREPARE);
+    lifecycle.transition(service.EVENTS.START);
+    assert.equal(lifecycle.isRecording(), true);
+
+    lifecycle.transition(service.EVENTS.PAUSE);
+    assert.equal(lifecycle.isRecording(), true);
+    assert.equal(lifecycle.isPaused(), true);
+
+    lifecycle.transition(service.EVENTS.STOP);
+    assert.equal(lifecycle.isRecording(), false);
+    assert.equal(lifecycle.isPaused(), false);
+    assert.equal(lifecycle.isStopping(), true);
+  });
+
+  it('notifies listeners after a valid state change and supports unsubscribe', () => {
+    const service = loadService();
+    const lifecycle = service.create();
+    const notifications = [];
+    const unsubscribe = lifecycle.onStateChange((nextState, previousState, event) => {
+      notifications.push({ nextState, previousState, event });
+    });
+
+    lifecycle.transition(service.EVENTS.PREPARE);
+    unsubscribe();
+    lifecycle.transition(service.EVENTS.START);
+
+    assert.deepEqual(notifications, [
+      {
+        nextState: service.STATES.PREPARING,
+        previousState: service.STATES.IDLE,
+        event: service.EVENTS.PREPARE
+      }
+    ]);
+  });
+
+  it('warns and rejects an invalid transition without changing state', () => {
+    const warnings = [];
+    const service = loadService({
+      warn(message) {
+        warnings.push(message);
+      }
+    });
+    const lifecycle = service.create();
+
+    assert.equal(lifecycle.transition(service.EVENTS.SUSPEND), false);
+    assert.equal(lifecycle.getState(), service.STATES.IDLE);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /Rejected transition/);
+  });
+});


### PR DESCRIPTION
## Summary

- add a DOM-independent recorder lifecycle state machine with seven explicit states
- derive `AppState.isRecording`, `isPaused`, and `isStopping` from the lifecycle service as the single source of truth
- replace all legacy boolean assignments in recording start, pause, resume, failure recovery, and cleanup paths with state transitions
- predefine `suspended` and `resuming` transitions for the follow-up PR without changing current interruption behavior
- add unit coverage for normal flows, derived legacy flags, notifications, unsubscribe, and invalid-transition rejection

## Why

Recorder state was spread across three independently writable booleans in `app.js`. This made contradictory UI and pipeline states possible and left no reliable foundation for the explicit suspend/resume behavior planned in #158. This PR centralizes state while intentionally preserving current observable recording behavior.

## Scope and behavior

- no suspend detection, safe-stop UI, or resume action is introduced here
- `recorderStopReason` and the existing MediaRecorder/STT pipeline remain unchanged
- invalid transitions warn and return `false`; they do not throw
- existing files were not reformatted; only the two new files were checked with Prettier

## Validation

- `npm run test:unit` — 243 passed
- `npx eslint .`
- `npm run test:ui-smoke`
- `npm run test:e2e`
- `npm run test:config-smoke`
- `npx prettier --check js/services/recorder-lifecycle-service.js tests/unit/recorder-lifecycle-service.test.mjs`
- `git diff --check`

Closes #177
Refs #158
