### PR TITLE
docs: handoff 2026-07-11（#158 スマホ対応パス前半完了）

### DIFF
--- a/handoff/status-2026-07-11.md
+++ b/handoff/status-2026-07-11.md
@@ -1,0 +1,43 @@
+# handoff 2026-07-11 — ai-meeting-assistant / スマホ対応パス（#158）前半完了
+
+## 1. HUMAN判断待ち（最初に読む）
+
+- **判断事項1**: 本handoff PRのmerge
+- **判断事項2**: PR-B着手のタイミング — Codexに Issue #179 のURLを渡せば着手可能（指示書は自己完結）
+- 期限・緊急度: 急ぎなし / 中（#158の本丸。毎日の利用品質に直結）
+- 判断しない場合の影響: スリープ中断が「録音中表示のまま無音」になる既存挙動が残る
+
+## 2. 現在地
+
+- 作業状態: #158 スマホ対応パスの前半（実機検証・原因分析・APIキー永続化・SM基盤）完了。後半（PR-B/PR-C）はCodex着手待ち
+- open PR: なし / open Issue: #158（本丸・進行中）、#179（PR-B指示書）、#159・#160（既存の別件）
+- 体制: 実装=Codex / レビュー=KURO / マージ=HUMAN / 方針=Gino
+
+## 3. 今回やったこと（2026-07-11、すべてmerge済み）
+
+1. **iPhone XR実機検証と原因分析**（#158にコメント記録）: ①APIキー非保持＝モバイル一律無効の仕様 ②スリープ中断が無処理（`onInterruption`が`background`を処理しない）③復帰時はWake Lock再取得のみで回復処理なし ④Wake Lockは正常
+2. **#172/#173**: 最大録音時間ガード（既定120分・0で無制限、切り忘れによるSTT課金垂れ流し防止）
+3. **#174/#175/#176**: モバイルPWAのAPIキー永続保存（既定OFF・オプトイン）。Codex実装＋KURO hotfix（iOSホーム画面Web Appはdisplay-modeメディアクエリに一致しないため`navigator.standalone === true`を判定に追加）。**実機受入合格**
+4. **Gino設計方針の決定と記録**（#158コメント）: 案A採用（安全停止＋明示的再開、信頼性>UX）、State Machine化、PR分割A→B→C承認
+5. **#177/#178（PR-A）**: 録音ライフサイクルの7状態State Machine抽出（挙動不変）。KUROレビューでPlaywright実挙動検証18項目ALL PASS（フェイクマイクで開始→一時停止→再開→停止→再スタートを駆動、不正遷移警告ゼロ）
+6. **#179（PR-B指示書）**: Suspend検知・安全停止・中断UI・ワンタップ再開。Codexがそのまま着手できる粒度
+
+## 4. 重要な発見・リスク
+
+- **iOS PWA検出**: `matchMedia('(display-mode: standalone)')`はiOSホーム画面Web Appで一致しないことがある（iPhone XR/iOS 18.7実機で確認）。`navigator.standalone === true`の併用が必須
+- **PR-Bの設計制約（指示書に明記済み）**: デスクトップはタブ切替（hidden）でも録音継続が正常挙動。hidden単独でsuspendedにせず、パイプライン死亡シグナルまたはvisible復帰時の最小健全性チェックで中断を確定する
+- **AppState.isRecording等はgetterのみ**（PR-Aでsetter撤去）: 以後のコードで代入すると非strictでは静かに無視される。必ず`recorderLifecycle.transition()`を使うこと
+- Prettierはベースライン非準拠ファイルが多数（CIは lint+ui-smoke のみ）。既存ファイルの一括再フォーマット禁止、新規ファイルのみ準拠
+
+## 5. 次の一手（AI別）
+
+- HUMAN: handoff PRのmerge → Codexに #179 を渡す → PR-B merge後にiPhone XR実機受入（スリープ→復帰→再開）
+- KURO: PR-Bのレビュー（デスクトップのタブ切替回帰＋track強制killでのsuspended遷移をPlaywrightで検証予定）
+- Gino: なし（方針決定済み。PR-Bで設計逸脱が出た場合のみ再相談）
+- JEM: なし
+
+## 6. 参照リンク
+
+- Issue: #158（正本: 検証結果・Gino方針の各コメント）/ #179（PR-B指示書）/ クローズ: #172, #174, #177
+- PR（merge済み）: #173, #175, #176, #178
+- Todoist: プロジェクト「ai-meeting-assistant」親カードのコメントに本handoff要約を投稿


### PR DESCRIPTION
2026-07-11の節目handoff。詳細は `handoff/status-2026-07-11.md` を参照。

- 実機検証・原因分析（#158コメント）、#172/#173、#174/#175/#176（実機受入合格）、Gino方針決定、#177/#178（PR-A）まで完了
- 次: Codexに #179（PR-B指示書）を渡す

🤖 Generated with [Claude Code](https://claude.com/claude-code)