### PR TITLE
feat: classify recorder pipeline health

### DIFF
--- a/js/services/recorder-lifecycle-service.js
+++ b/js/services/recorder-lifecycle-service.js
@@ -103,8 +103,7 @@ const RecorderLifecycleService = (function () {
     if (stream !== undefined) {
       if (stream?.present !== true) {
         reasons.push('missing_stream');
-      }
-      if (stream?.active !== true) {
+      } else if (stream.active !== true) {
         reasons.push('inactive_stream');
       }
     }
@@ -125,9 +124,9 @@ const RecorderLifecycleService = (function () {
     }
 
     if (stt?.required === true) {
-      if (stt.status === 'reconnecting') {
+      if (stt.status === 'reconnecting' || stt.status === 'connecting') {
         reasons.push('stt_reconnecting');
-      } else if (stt.status === 'disconnected') {
+      } else if (stt.status !== 'connected') {
         reasons.push('stt_disconnected');
       }
     }
@@ -136,7 +135,11 @@ const RecorderLifecycleService = (function () {
       reasons.push('pcm_inactive');
     }
 
-    if (recorder?.required === true && recorder.state === 'inactive') {
+    if (
+      recorder?.required === true &&
+      recorder.state !== 'recording' &&
+      recorder.state !== 'paused'
+    ) {
       reasons.push('recorder_inactive');
     }
 

--- a/js/services/recorder-lifecycle-service.js
+++ b/js/services/recorder-lifecycle-service.js
@@ -63,8 +63,52 @@ const RecorderLifecycleService = (function () {
     STATES.RESUMING
   ]);
 
-  function evaluatePipelineHealth({ tracks = [], audioContextState = null } = {}) {
+  const PIPELINE_HEALTH_STATUS = Object.freeze({
+    HEALTHY: 'healthy',
+    RECOVERABLE: 'recoverable',
+    UNHEALTHY: 'unhealthy'
+  });
+
+  const PIPELINE_HEALTH_REASON_STATUS = Object.freeze({
+    missing_stream: PIPELINE_HEALTH_STATUS.UNHEALTHY,
+    inactive_stream: PIPELINE_HEALTH_STATUS.UNHEALTHY,
+    missing_audio_track: PIPELINE_HEALTH_STATUS.UNHEALTHY,
+    audio_track_ended: PIPELINE_HEALTH_STATUS.UNHEALTHY,
+    audio_track_muted: PIPELINE_HEALTH_STATUS.RECOVERABLE,
+    audio_context_suspended: PIPELINE_HEALTH_STATUS.RECOVERABLE,
+    audio_context_interrupted: PIPELINE_HEALTH_STATUS.RECOVERABLE,
+    audio_context_closed: PIPELINE_HEALTH_STATUS.UNHEALTHY,
+    stt_reconnecting: PIPELINE_HEALTH_STATUS.RECOVERABLE,
+    stt_disconnected: PIPELINE_HEALTH_STATUS.UNHEALTHY,
+    pcm_inactive: PIPELINE_HEALTH_STATUS.UNHEALTHY,
+    recorder_inactive: PIPELINE_HEALTH_STATUS.UNHEALTHY
+  });
+
+  const PIPELINE_HEALTH_STATUS_PRIORITY = Object.freeze({
+    [PIPELINE_HEALTH_STATUS.HEALTHY]: 0,
+    [PIPELINE_HEALTH_STATUS.RECOVERABLE]: 1,
+    [PIPELINE_HEALTH_STATUS.UNHEALTHY]: 2
+  });
+
+  function evaluatePipelineHealth({
+    tracks = [],
+    audioContextState = null,
+    stream,
+    stt,
+    pcm,
+    recorder
+  } = {}) {
     const reasons = [];
+
+    if (stream !== undefined) {
+      if (stream?.present !== true) {
+        reasons.push('missing_stream');
+      }
+      if (stream?.active !== true) {
+        reasons.push('inactive_stream');
+      }
+    }
+
     if (!Array.isArray(tracks) || tracks.length === 0) {
       reasons.push('missing_audio_track');
     } else {
@@ -80,8 +124,34 @@ const RecorderLifecycleService = (function () {
       reasons.push(`audio_context_${audioContextState}`);
     }
 
+    if (stt?.required === true) {
+      if (stt.status === 'reconnecting') {
+        reasons.push('stt_reconnecting');
+      } else if (stt.status === 'disconnected') {
+        reasons.push('stt_disconnected');
+      }
+    }
+
+    if (pcm?.required === true && pcm.active !== true) {
+      reasons.push('pcm_inactive');
+    }
+
+    if (recorder?.required === true && recorder.state === 'inactive') {
+      reasons.push('recorder_inactive');
+    }
+
+    const status = reasons.reduce((worstStatus, reason) => {
+      const reasonStatus =
+        PIPELINE_HEALTH_REASON_STATUS[reason] || PIPELINE_HEALTH_STATUS.UNHEALTHY;
+      return PIPELINE_HEALTH_STATUS_PRIORITY[reasonStatus] >
+        PIPELINE_HEALTH_STATUS_PRIORITY[worstStatus]
+        ? reasonStatus
+        : worstStatus;
+    }, PIPELINE_HEALTH_STATUS.HEALTHY);
+
     return Object.freeze({
-      healthy: reasons.length === 0,
+      healthy: status === PIPELINE_HEALTH_STATUS.HEALTHY,
+      status,
       reasons: Object.freeze(reasons)
     });
   }
@@ -149,6 +219,8 @@ const RecorderLifecycleService = (function () {
   return Object.freeze({
     STATES,
     EVENTS,
+    PIPELINE_HEALTH_STATUS,
+    PIPELINE_HEALTH_REASON_STATUS,
     evaluatePipelineHealth,
     shouldSuspendForInterruption,
     create

--- a/tests/unit/recorder-lifecycle-service.test.mjs
+++ b/tests/unit/recorder-lifecycle-service.test.mjs
@@ -215,6 +215,49 @@ describe('RecorderLifecycleService', () => {
     );
   });
 
+  it('fails closed when required STT status is unavailable', () => {
+    const service = loadService();
+    const result = service.evaluatePipelineHealth({
+      tracks: [{ readyState: 'live', muted: false }],
+      stt: { required: true, status: undefined }
+    });
+
+    assert.equal(result.status, service.PIPELINE_HEALTH_STATUS.UNHEALTHY);
+    assert.deepEqual([...result.reasons], ['stt_disconnected']);
+  });
+
+  it('treats connecting STT as recoverable during reconnection', () => {
+    const service = loadService();
+    const result = service.evaluatePipelineHealth({
+      tracks: [{ readyState: 'live', muted: false }],
+      stt: { required: true, status: 'connecting' }
+    });
+
+    assert.equal(result.status, service.PIPELINE_HEALTH_STATUS.RECOVERABLE);
+    assert.deepEqual([...result.reasons], ['stt_reconnecting']);
+  });
+
+  it('fails closed when required recorder state is unavailable', () => {
+    const service = loadService();
+    const result = service.evaluatePipelineHealth({
+      tracks: [{ readyState: 'live', muted: false }],
+      recorder: { required: true, state: undefined }
+    });
+
+    assert.equal(result.status, service.PIPELINE_HEALTH_STATUS.UNHEALTHY);
+    assert.deepEqual([...result.reasons], ['recorder_inactive']);
+  });
+
+  it('reports only missing_stream when the stream is absent', () => {
+    const service = loadService();
+    const result = service.evaluatePipelineHealth({
+      tracks: [{ readyState: 'live', muted: false }],
+      stream: { present: false, active: false }
+    });
+
+    assert.deepEqual([...result.reasons], ['missing_stream']);
+  });
+
   it('uses unhealthy as the worst status when reason classes are mixed', () => {
     const service = loadService();
     const result = service.evaluatePipelineHealth({

--- a/tests/unit/recorder-lifecycle-service.test.mjs
+++ b/tests/unit/recorder-lifecycle-service.test.mjs
@@ -133,6 +133,7 @@ describe('RecorderLifecycleService', () => {
     });
 
     assert.equal(result.healthy, true);
+    assert.equal(result.status, service.PIPELINE_HEALTH_STATUS.HEALTHY);
     assert.deepEqual([...result.reasons], []);
   });
 
@@ -169,5 +170,84 @@ describe('RecorderLifecycleService', () => {
     );
     assert.equal(service.shouldSuspendForInterruption('background'), false);
     assert.equal(service.shouldSuspendForInterruption('page_frozen'), false);
+  });
+
+  it('keeps the legacy input and healthy result fields backward compatible', () => {
+    const service = loadService();
+    const result = service.evaluatePipelineHealth();
+
+    assert.equal(result.healthy, false);
+    assert.equal(result.status, service.PIPELINE_HEALTH_STATUS.UNHEALTHY);
+    assert.deepEqual([...result.reasons], ['missing_audio_track']);
+  });
+
+  it('reports each extended pipeline reason independently', () => {
+    const service = loadService();
+    const liveTrack = [{ readyState: 'live', muted: false }];
+    const cases = [
+      [{ tracks: liveTrack, stream: { present: false, active: true } }, 'missing_stream'],
+      [{ tracks: liveTrack, stream: { present: true, active: false } }, 'inactive_stream'],
+      [{ tracks: liveTrack, stt: { required: true, status: 'reconnecting' } }, 'stt_reconnecting'],
+      [{ tracks: liveTrack, stt: { required: true, status: 'disconnected' } }, 'stt_disconnected'],
+      [{ tracks: liveTrack, pcm: { required: true, active: false } }, 'pcm_inactive'],
+      [{ tracks: liveTrack, recorder: { required: true, state: 'inactive' } }, 'recorder_inactive']
+    ];
+
+    cases.forEach(([snapshot, expectedReason]) => {
+      const result = service.evaluatePipelineHealth(snapshot);
+      assert.deepEqual([...result.reasons], [expectedReason]);
+    });
+  });
+
+  it('classifies recoverable reasons without marking the pipeline healthy', () => {
+    const service = loadService();
+    const result = service.evaluatePipelineHealth({
+      tracks: [{ readyState: 'live', muted: true }],
+      audioContextState: 'suspended',
+      stt: { required: true, status: 'reconnecting' }
+    });
+
+    assert.equal(result.healthy, false);
+    assert.equal(result.status, service.PIPELINE_HEALTH_STATUS.RECOVERABLE);
+    assert.deepEqual(
+      [...result.reasons],
+      ['audio_track_muted', 'audio_context_suspended', 'stt_reconnecting']
+    );
+  });
+
+  it('uses unhealthy as the worst status when reason classes are mixed', () => {
+    const service = loadService();
+    const result = service.evaluatePipelineHealth({
+      tracks: [{ readyState: 'live', muted: true }],
+      stt: { required: true, status: 'disconnected' }
+    });
+
+    assert.equal(result.status, service.PIPELINE_HEALTH_STATUS.UNHEALTHY);
+    assert.deepEqual([...result.reasons], ['audio_track_muted', 'stt_disconnected']);
+  });
+
+  it('skips optional checks when blocks are omitted or not required', () => {
+    const service = loadService();
+    const result = service.evaluatePipelineHealth({
+      tracks: [{ readyState: 'live', muted: false }],
+      stt: { required: false, status: 'disconnected' },
+      pcm: { required: false, active: false },
+      recorder: { required: false, state: 'inactive' }
+    });
+
+    assert.equal(result.status, service.PIPELINE_HEALTH_STATUS.HEALTHY);
+    assert.deepEqual([...result.reasons], []);
+  });
+
+  it('freezes classification constants and evaluation results', () => {
+    const service = loadService();
+    const result = service.evaluatePipelineHealth({
+      tracks: [{ readyState: 'live', muted: false }]
+    });
+
+    assert.equal(Object.isFrozen(service.PIPELINE_HEALTH_STATUS), true);
+    assert.equal(Object.isFrozen(service.PIPELINE_HEALTH_REASON_STATUS), true);
+    assert.equal(Object.isFrozen(result), true);
+    assert.equal(Object.isFrozen(result.reasons), true);
   });
 });


### PR DESCRIPTION
## Summary

- extend the existing DOM-independent pipeline health snapshot with optional stream, STT, PCM, and MediaRecorder blocks
- add reason codes for missing/inactive streams, Deepgram reconnect/disconnect states, inactive PCM processing, and inactive MediaRecorder state
- classify results as `healthy`, `recoverable`, or `unhealthy` while preserving the existing `healthy` boolean and reason names
- export frozen status and reason-classification maps for PR-C2 integration
- add backward-compatibility, reason, precedence, optional-check, and immutability tests

## Why

PR-C2 needs one shared policy for deciding whether a restored recording pipeline is healthy, temporarily recoverable, or definitively unhealthy. Extending the existing evaluator avoids a duplicate service and keeps browser objects out of the policy layer.

## Compatibility and scope

- existing `{ tracks, audioContextState }` callers continue to receive the same `healthy` value and reasons
- omitted blocks are not evaluated
- STT, PCM, and recorder blocks are evaluated only when `required: true`
- required STT and recorder state checks fail closed when their state is missing or unknown; STT `connecting`/`reconnecting` remains recoverable
- `app.js`, UI, i18n, timers, diagnostics, and runtime behavior are unchanged

## Validation

- `npm run test:unit` — 258 passed
- `npx eslint .`
- `npm run test:i18n`
- `npm run test:ui-smoke`
- `npm run test:e2e`
- `npm run test:config-smoke`
- Prettier and `git diff --check`
- confirmed the diff contains only the lifecycle service and its unit test

Closes #183
Refs #158
