### PR TITLE
feat: integrate recorder pipeline health checks

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2608,12 +2608,6 @@ function getRecorderPipelineHealth() {
 async function suspendRecording(reason) {
   if (suspensionPromise) return suspensionPromise;
 
-  if (typeof DebugLogger !== 'undefined') {
-    DebugLogger.log('[RecorderHealth]', 'Suspending recording', {
-      reasons: String(reason || 'unknown').split(',').filter(Boolean)
-    });
-  }
-
   const suspendableStates = [
     RecorderLifecycleService.STATES.RECORDING,
     RecorderLifecycleService.STATES.PAUSED,
@@ -2621,6 +2615,12 @@ async function suspendRecording(reason) {
   ];
   if (!suspendableStates.includes(AppState.recorderLifecycleState)) return false;
   if (!recorderLifecycle.transition(RecorderLifecycleService.EVENTS.SUSPEND)) return false;
+
+  if (typeof DebugLogger !== 'undefined') {
+    DebugLogger.log('[RecorderHealth]', 'Suspending recording', {
+      reasons: String(reason || 'unknown').split(',').filter(Boolean)
+    });
+  }
 
   if (!AppState.pauseStartedAt) {
     AppState.pauseStartedAt = Date.now();
@@ -2797,6 +2797,7 @@ async function handleVisibleRecordingHealthCheck() {
     if (mutedOnlyRecoverable) {
       const mutedSince = Date.now();
       while (true) {
+        if (!checkableStates.includes(AppState.recorderLifecycleState)) return;
         if (RecorderLifecycleService.isMutedHealthConfirmed({ mutedSince })) {
           const reason = health.reasons.join(',');
           console.warn('[Monitor] Audio track remained muted after visibility restore:', health.reasons);
@@ -2813,6 +2814,7 @@ async function handleVisibleRecordingHealthCheck() {
       }
     }
 
+    if (health.status === RecorderLifecycleService.PIPELINE_HEALTH_STATUS.HEALTHY) return;
     if (health.status === RecorderLifecycleService.PIPELINE_HEALTH_STATUS.RECOVERABLE) {
       // STT reconnecting and transient audio signals are allowed to recover in place.
       return;

--- a/js/app.js
+++ b/js/app.js
@@ -23,6 +23,7 @@ let finalStopResolve = null;
 let recorderStopReason = null;
 let recorderRestartTimeoutId = null;
 let activeProviderId = null;
+let sttConnectionStatus = null;
 let activeMeetingDraftId = null;
 let activeMeetingDraftStartedAt = null;
 let activeMeetingDraftSaveTimer = null;
@@ -194,6 +195,8 @@ const AppState = {
   set recorderRestartTimeoutId(value) { recorderRestartTimeoutId = value; },
   get activeProviderId() { return activeProviderId; },
   set activeProviderId(value) { activeProviderId = value; },
+  get sttConnectionStatus() { return sttConnectionStatus; },
+  set sttConnectionStatus(value) { sttConnectionStatus = value; },
   get activeMeetingDraftId() { return activeMeetingDraftId; },
   set activeMeetingDraftId(value) { activeMeetingDraftId = value; },
   get activeMeetingDraftStartedAt() { return activeMeetingDraftStartedAt; },
@@ -1864,6 +1867,7 @@ async function validateSTTProviderForRecording(provider) {
 // =====================================
 async function startChunkedRecording(provider) {
   console.log('[Chunked] Starting recording for provider:', provider);
+  AppState.sttConnectionStatus = null;
 
   // iOS Safari対応: startRecording()で既に取得済みのストリームを再利用
   // 二重取得を防止し、Safari/Chrome両対応を維持
@@ -1919,6 +1923,7 @@ async function startChunkedRecording(provider) {
 // =====================================
 async function startStreamingRecording(provider) {
   console.log('[Streaming] Starting recording for provider:', provider);
+  AppState.sttConnectionStatus = null;
 
   // プロバイダーインスタンスを作成
   switch (provider) {
@@ -1944,6 +1949,21 @@ async function startStreamingRecording(provider) {
 
   AppState.currentSTTProvider.setOnStatusChange((status) => {
     console.log('[Streaming] Status:', status);
+    AppState.sttConnectionStatus = status;
+    if (
+      status === 'disconnected' &&
+      AppState.recorderLifecycleState === RecorderLifecycleService.STATES.RECORDING
+    ) {
+      if (typeof DebugLogger !== 'undefined') {
+        DebugLogger.log('[RecorderHealth]', 'STT disconnected during recording', {
+          status,
+          reasons: ['stt_disconnected']
+        });
+      }
+      suspendRecording('stt_disconnected').catch(error => {
+        console.error('[RecorderHealth] STT disconnect handling failed:', error);
+      });
+    }
     if (
       AppState.recorderLifecycleState === RecorderLifecycleService.STATES.SUSPENDED ||
       AppState.recorderLifecycleState === RecorderLifecycleService.STATES.RESUMING
@@ -2304,6 +2324,7 @@ async function cleanupRecording() {
   if (AppState.currentSTTProvider) {
     await AppState.currentSTTProvider.stop();
     AppState.currentSTTProvider = null;
+    AppState.sttConnectionStatus = null;
     console.log('[Cleanup] STT provider stopped');
   }
 
@@ -2319,6 +2340,7 @@ async function cleanupRecording() {
   recorderLifecycle.transition(RecorderLifecycleService.EVENTS.FINISH);
   AppState.recorderStopReason = null;
   AppState.activeProviderId = null;
+  AppState.sttConnectionStatus = null;
 
   console.log('[Cleanup] Cleanup complete');
 }
@@ -2552,17 +2574,45 @@ function getRecorderPipelineHealth() {
       ? AppState.currentAudioStream.getTracks().filter(track => track.kind === 'audio')
       : [];
   const audioContextState = AppState.pcmStreamProcessor?.audioContext?.state || null;
+  const isStreaming = STREAMING_PROVIDERS.has(AppState.activeProviderId);
+  const requirements = RecorderLifecycleService.derivePipelineRequirements({
+    state: AppState.recorderLifecycleState,
+    isStreaming
+  });
+  const isRecorderRestarting = AppState.recorderRestartTimeoutId !== null;
   return RecorderLifecycleService.evaluatePipelineHealth({
     tracks: tracks.map(track => ({
       readyState: track.readyState,
       muted: track.muted
     })),
-    audioContextState
+    audioContextState,
+    stream: {
+      present: AppState.currentAudioStream != null,
+      active: AppState.currentAudioStream?.active === true
+    },
+    stt: {
+      required: requirements.stt,
+      status: AppState.sttConnectionStatus
+    },
+    pcm: {
+      required: requirements.pcm,
+      active: AppState.pcmStreamProcessor?.isActive() === true
+    },
+    recorder: {
+      required: requirements.recorder && !isRecorderRestarting,
+      state: AppState.mediaRecorder?.state
+    }
   });
 }
 
 async function suspendRecording(reason) {
   if (suspensionPromise) return suspensionPromise;
+
+  if (typeof DebugLogger !== 'undefined') {
+    DebugLogger.log('[RecorderHealth]', 'Suspending recording', {
+      reasons: String(reason || 'unknown').split(',').filter(Boolean)
+    });
+  }
 
   const suspendableStates = [
     RecorderLifecycleService.STATES.RECORDING,
@@ -2627,6 +2677,7 @@ async function suspendRecording(reason) {
         console.warn('[Suspend] STT provider stop failed:', error);
       }
       AppState.currentSTTProvider = null;
+      AppState.sttConnectionStatus = null;
     }
 
     if (AppState.currentAudioStream) {
@@ -2731,14 +2782,43 @@ async function handleVisibleRecordingHealthCheck() {
     }
 
     let health = getRecorderPipelineHealth();
-    if (health.reasons.includes('audio_track_muted')) {
-      await new Promise(resolve => setTimeout(resolve, 250));
-      health = getRecorderPipelineHealth();
+    if (typeof DebugLogger !== 'undefined') {
+      DebugLogger.log('[RecorderHealth]', 'Visible pipeline health check', {
+        status: health.status,
+        reasons: health.reasons
+      });
     }
-    if (!health.healthy) {
-      console.warn('[Monitor] Unhealthy pipeline after visibility restore:', health.reasons);
-      await suspendRecording(health.reasons.join(','));
+
+    if (health.status === RecorderLifecycleService.PIPELINE_HEALTH_STATUS.HEALTHY) return;
+
+    const mutedOnlyRecoverable =
+      health.status === RecorderLifecycleService.PIPELINE_HEALTH_STATUS.RECOVERABLE &&
+      health.reasons.includes('audio_track_muted');
+    if (mutedOnlyRecoverable) {
+      const mutedSince = Date.now();
+      while (true) {
+        if (RecorderLifecycleService.isMutedHealthConfirmed({ mutedSince })) {
+          const reason = health.reasons.join(',');
+          console.warn('[Monitor] Audio track remained muted after visibility restore:', health.reasons);
+          await suspendRecording(reason);
+          return;
+        }
+        await new Promise(resolve => setTimeout(resolve, 250));
+        health = getRecorderPipelineHealth();
+        if (!health.reasons.includes('audio_track_muted')) break;
+        if (health.status === RecorderLifecycleService.PIPELINE_HEALTH_STATUS.UNHEALTHY) {
+          await suspendRecording(health.reasons.join(','));
+          return;
+        }
+      }
     }
+
+    if (health.status === RecorderLifecycleService.PIPELINE_HEALTH_STATUS.RECOVERABLE) {
+      // STT reconnecting and transient audio signals are allowed to recover in place.
+      return;
+    }
+    console.warn('[Monitor] Unhealthy pipeline after visibility restore:', health.reasons);
+    await suspendRecording(health.reasons.join(','));
   } catch (error) {
     console.error('[Monitor] Visible health check failed:', error);
     await suspendRecording('health_check_failed');

--- a/js/services/recorder-lifecycle-service.js
+++ b/js/services/recorder-lifecycle-service.js
@@ -159,6 +159,20 @@ const RecorderLifecycleService = (function () {
     });
   }
 
+  function derivePipelineRequirements({ state, isStreaming = false } = {}) {
+    const recording = state === STATES.RECORDING;
+    return Object.freeze({
+      stt: recording && isStreaming,
+      pcm: recording && isStreaming,
+      recorder: recording && !isStreaming
+    });
+  }
+
+  function isMutedHealthConfirmed({ mutedSince, now = Date.now(), graceMs = 1500 } = {}) {
+    if (!Number.isFinite(mutedSince) || !Number.isFinite(now)) return false;
+    return now - mutedSince >= graceMs;
+  }
+
   function shouldSuspendForInterruption(reason, { audioContextResumed = false } = {}) {
     if (reason === 'stream_ended') return true;
     if (reason === 'audiocontext_suspended') return audioContextResumed !== true;
@@ -225,6 +239,8 @@ const RecorderLifecycleService = (function () {
     PIPELINE_HEALTH_STATUS,
     PIPELINE_HEALTH_REASON_STATUS,
     evaluatePipelineHealth,
+    derivePipelineRequirements,
+    isMutedHealthConfirmed,
     shouldSuspendForInterruption,
     create
   });

--- a/tests/unit/recorder-lifecycle-service.test.mjs
+++ b/tests/unit/recorder-lifecycle-service.test.mjs
@@ -258,6 +258,47 @@ describe('RecorderLifecycleService', () => {
     assert.deepEqual([...result.reasons], ['missing_stream']);
   });
 
+  it('derives required pipeline blocks from lifecycle state and recording mode', () => {
+    const service = loadService();
+
+    assert.deepEqual(
+      {
+        ...service.derivePipelineRequirements({
+          state: service.STATES.RECORDING,
+          isStreaming: true
+        })
+      },
+      { stt: true, pcm: true, recorder: false }
+    );
+    assert.deepEqual(
+      {
+        ...service.derivePipelineRequirements({
+          state: service.STATES.RECORDING,
+          isStreaming: false
+        })
+      },
+      { stt: false, pcm: false, recorder: true }
+    );
+    assert.deepEqual(
+      {
+        ...service.derivePipelineRequirements({ state: service.STATES.PAUSED, isStreaming: true })
+      },
+      { stt: false, pcm: false, recorder: false }
+    );
+  });
+
+  it('confirms muted health only after the configured grace period', () => {
+    const service = loadService();
+
+    assert.equal(service.isMutedHealthConfirmed({ mutedSince: 1000, now: 1249 }), false);
+    assert.equal(
+      service.isMutedHealthConfirmed({ mutedSince: 1000, now: 1250, graceMs: 250 }),
+      true
+    );
+    assert.equal(service.isMutedHealthConfirmed({ mutedSince: 1000, now: 2499 }), false);
+    assert.equal(service.isMutedHealthConfirmed({ mutedSince: 1000, now: 2500 }), true);
+  });
+
   it('uses unhealthy as the worst status when reason classes are mixed', () => {
     const service = loadService();
     const result = service.evaluatePipelineHealth({

--- a/tests/unit/recorder-lifecycle-service.test.mjs
+++ b/tests/unit/recorder-lifecycle-service.test.mjs
@@ -299,6 +299,19 @@ describe('RecorderLifecycleService', () => {
     assert.equal(service.isMutedHealthConfirmed({ mutedSince: 1000, now: 2500 }), true);
   });
 
+  it('returns healthy when a muted track recovers within the grace period', () => {
+    const service = loadService();
+    const snapshot = {
+      tracks: [{ readyState: 'live', muted: false }],
+      audioContextState: 'running'
+    };
+
+    assert.equal(
+      service.evaluatePipelineHealth(snapshot).status,
+      service.PIPELINE_HEALTH_STATUS.HEALTHY
+    );
+  });
+
   it('uses unhealthy as the worst status when reason classes are mixed', () => {
     const service = loadService();
     const result = service.evaluatePipelineHealth({


### PR DESCRIPTION
## Summary

- integrate the existing pipeline health evaluator into visible-resume recording checks
- persist the latest streaming STT status in `AppState.sttConnectionStatus`
- derive required STT/PCM/MediaRecorder checks from lifecycle state and recording mode
- wait up to 1.5 seconds (250 ms intervals) for transient muted tracks to recover
- suspend only on final STT disconnect while actively recording; reconnecting remains recoverable
- skip required MediaRecorder checks during chunk recorder restart windows
- record only pipeline status and reason codes through `DebugLogger`
- add pure unit-tested helpers for required-state derivation and muted grace confirmation

## Why

PR-C1 added full pipeline health classification, but the app still passed only tracks and AudioContext state during visible-resume checks. This left STT, PCM, stream, and MediaRecorder failures undetected and could leave the UI showing recording while no audio was being processed.

## Compatibility and safety

- hidden/background transitions remain event-driven and do not trigger polling or automatic resume
- paused recordings do not require STT, PCM, or MediaRecorder to be active
- intentional pause/stop provider disconnects cannot trigger suspension because the lifecycle state is no longer `recording`
- chunked recorder stop/restart gaps are excluded from recorder health requirements
- no API keys, audio, transcript text, or device identifiers are logged

## Validation

- `npm run test:unit` — 260 passed
- `npx eslint .`
- `npm run test:i18n`
- `npm run test:ui-smoke`
- `npm run test:e2e`
- `npm run test:config-smoke`
- `git diff --check`

Closes #185
Refs #158
