### PR TITLE
fix: preserve restored history profile

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -6055,6 +6055,7 @@ async function saveHistorySnapshot() {
       if (original) {
         record.id = AppState.restoredHistoryId;
         record.createdAt = original.createdAt; // 元の作成日時を維持
+        record.profile = original.profile; // 復元元の録音プロファイルを維持
       }
     } catch (e) {
       console.warn('[History] Failed to get original record for overwrite', e);

--- a/scripts/test-recording-profiles.mjs
+++ b/scripts/test-recording-profiles.mjs
@@ -113,6 +113,26 @@ async function runProfileFlow(page) {
   assert(meetingRecord.profile === 'meeting', `meeting record profile mismatch: ${meetingRecord.profile}`);
   assert(meetingRecord.status === 'raw', 'meeting raw autosave regressed');
 
+  const restoredMemoRecord = await page.evaluate(async id => {
+    confirm = () => true;
+    await restoreFromHistory(id);
+    await saveHistorySnapshot();
+    const record = await HistoryStore.get(id);
+    return {
+      id: record.id,
+      profile: record.profile,
+      restoredHistoryId: AppState.restoredHistoryId,
+      lastSavedHistoryId: AppState.lastSavedHistoryId
+    };
+  }, memoRecord.id);
+  assert(restoredMemoRecord.id === memoRecord.id, 'restored memo was not overwritten in place');
+  assert(
+    restoredMemoRecord.profile === 'memo',
+    `restored memo profile changed to the active UI profile: ${restoredMemoRecord.profile}`
+  );
+  assert(restoredMemoRecord.restoredHistoryId === null, 'restored history id was not reset after overwrite');
+  assert(restoredMemoRecord.lastSavedHistoryId === memoRecord.id, 'last saved history id was not preserved');
+
   await page.reload({ waitUntil: 'domcontentloaded' });
   await page.waitForFunction(
     () => typeof AppState !== 'undefined' && document.documentElement.dataset.recordingProfile
@@ -168,7 +188,7 @@ async function run() {
       { timeout: 30000 }
     );
     await runProfileFlow(page);
-    console.log('\u001b[32m✓\u001b[0m P1 memo/meeting entry, persistence, raw save, and status UI');
+    console.log('\u001b[32m✓\u001b[0m P1 memo/meeting entry, persistence, restored overwrite, raw save, and status UI');
     await context.close();
   } finally {
     if (browser) await browser.close();


### PR DESCRIPTION
## Summary

- preserve the original history record `profile` when a restored recording is overwritten
- add P1 regression coverage for restoring a Memo record while the UI is in Meeting profile

## Root cause

PR #199 saved `AppState.recordingProfile` into every history snapshot. `restoreFromHistory()` did not switch the active UI profile, so overwriting a restored record from a different active profile could silently mutate its persisted and exported profile metadata.

## User impact

Restored Memo and Meeting records now retain their original profile when saved back to the same history record.

## Validation

- `git diff --check`
- `npx eslint .`
- `npm run test:unit` — 272/272 PASS
- `npm run test:ui-smoke` — PASS
- `npm run test:recording-profiles` — PASS

Follow-up to #199.