### PR TITLE
fix: restore history Markdown compatibility

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -6552,16 +6552,20 @@ function parseImportMarkdown(mdContent) {
     result.title = titleMatch[1].trim();
   }
 
-  // 文字起こし抽出（<details>タグ内）
-  const transcriptMatch = mdContent.match(/<details>[\s\S]*?<summary>[\s\S]*?<\/summary>\s*([\s\S]*?)\s*<\/details>/i);
+  // 文字起こし抽出（front matter付き新形式を優先し、従来の<details>形式へフォールバック）
+  const transcriptMatch =
+    mdContent.match(/^##\s+文字起こし[^\S\r\n]*\r?\n+([\s\S]*?)(?=\r?\n(?:---[^\S\r\n]*\r?\n+)?##\s+保存時の詳細出力（従来形式）[^\S\r\n]*(?:\r?\n|(?![\s\S]))|(?![\s\S]))/m) ||
+    mdContent.match(/<details>[\s\S]*?<summary>[\s\S]*?<\/summary>\s*([\s\S]*?)\s*<\/details>/i);
   if (transcriptMatch) {
     result.transcript = transcriptMatch[1].trim();
     // チャンクに変換
     result.transcriptChunks = parseTranscriptToChunks(result.transcript);
   }
 
-  // 議事録抽出（## 📝 で始まるセクション）
-  const minutesMatch = mdContent.match(/##\s*📝[^\n]*\n\n([\s\S]*?)(?=\n---|\n##|$)/);
+  // 議事録抽出（front matter付き新形式を優先し、従来の絵文字付き見出しへフォールバック）
+  const minutesMatch =
+    mdContent.match(/^##\s+議事録[^\S\r\n]*\r?\n+([\s\S]*?)(?=\r?\n##\s+文字起こし[^\S\r\n]*(?:\r?\n|(?![\s\S]))|(?![\s\S]))/m) ||
+    mdContent.match(/##\s*📝[^\n]*\n\n([\s\S]*?)(?=\n---|\n##|$)/);
   if (minutesMatch) {
     result.minutes = minutesMatch[1].trim();
     result.aiResponses.minutes = result.minutes;

--- a/js/services/export-service.js
+++ b/js/services/export-service.js
@@ -129,6 +129,20 @@ const ExportService = (function () {
     }
     lines.push('## 文字起こし', '', transcript);
 
+    const legacyExport = typeof source.exportMarkdown === 'string'
+      ? source.exportMarkdown.replace(/\r\n/g, '\n').trim()
+      : '';
+    if (legacyExport) {
+      lines.push(
+        '',
+        '---',
+        '',
+        '## 保存時の詳細出力（従来形式）',
+        '',
+        legacyExport
+      );
+    }
+
     return `${lines.join('\n').trimEnd()}\n`;
   }
 

--- a/scripts/test-history-export.mjs
+++ b/scripts/test-history-export.mjs
@@ -27,14 +27,15 @@ async function seedRecords(page) {
         category: '相談・確認',
         tags: ['財務: 重要', '#至急'],
         status: 'organized',
-        transcript: 'newest consultation transcript',
+        transcript: 'newest consultation transcript\nsecond transcript line',
         structured: {
           keyPoints: ['売上見込みを確認'],
           decisions: ['予算案を承認'],
           actionCandidates: ['見積を更新'],
           openQuestions: ['支払時期']
         },
-        minutes: '議事録の本文'
+        minutes: '議事録の本文',
+        exportMarkdown: '# 従来の資金確認\n\n## 💬 AI回答\n\nlegacy-summary-marker\n\n## 📝 議事録\n\nlegacy minutes\n\n## 📜 文字起こし\n\n<details>\n<summary>展開</summary>\n\nlegacy transcript\n\n</details>\n\n## 💰 コスト詳細\n\nlegacy-cost-marker\n'
       },
       {
         id: 'export-2',
@@ -96,7 +97,53 @@ async function runHistoryExport(page) {
   assert(single.content.includes('  - "財務: 重要"\n  - "#至急"'), 'YAML-safe tags are missing');
   assert(single.content.includes('## アクション候補\n\n以下は候補であり、確定タスクではありません。'), 'action candidate notice is missing');
   assert(single.content.includes('## 議事録\n\n議事録の本文'), 'meeting minutes are missing');
-  assert(single.content.includes('## 文字起こし\n\nnewest consultation transcript'), 'single transcript is missing');
+  assert(
+    single.content.includes('## 文字起こし\n\nnewest consultation transcript\nsecond transcript line'),
+    'single transcript is missing'
+  );
+  assert(single.content.includes('## 保存時の詳細出力（従来形式）'), 'legacy export appendix is missing');
+  assert(single.content.includes('legacy-summary-marker'), 'legacy AI response content was dropped');
+  assert(single.content.includes('legacy-cost-marker'), 'legacy cost content was dropped');
+
+  const roundTrip = await page.evaluate(markdown => {
+    const parsed = parseImportMarkdown(markdown);
+    return {
+      title: parsed?.title,
+      minutes: parsed?.aiResponses?.minutes,
+      transcript: parsed?.transcript
+    };
+  }, single.content);
+  assert(roundTrip.title === '資金: #確認', `round-trip title mismatch: ${roundTrip.title}`);
+  assert(roundTrip.minutes === '議事録の本文', `round-trip minutes mismatch: ${roundTrip.minutes}`);
+  assert(
+    roundTrip.transcript === 'newest consultation transcript\nsecond transcript line',
+    `round-trip transcript mismatch: ${roundTrip.transcript}`
+  );
+
+  const legacyImport = await page.evaluate(() => {
+    const parsed = parseImportMarkdown([
+      '# 従来形式',
+      '',
+      '## 📝 議事録',
+      '',
+      'legacy minutes only',
+      '',
+      '## 📜 文字起こし',
+      '',
+      '<details>',
+      '<summary>展開</summary>',
+      '',
+      'legacy transcript only',
+      '',
+      '</details>'
+    ].join('\n'));
+    return {
+      minutes: parsed?.aiResponses?.minutes,
+      transcript: parsed?.transcript
+    };
+  });
+  assert(legacyImport.minutes === 'legacy minutes only', 'legacy minutes import regressed');
+  assert(legacyImport.transcript === 'legacy transcript only', 'legacy transcript import regressed');
 
   await page.click('[data-action="back-to-list"]');
   await page.selectOption('#historyCategoryFilter', '相談・確認');
@@ -111,8 +158,33 @@ async function runHistoryExport(page) {
   assert(bulk.content.indexOf('id: "export-1"') < bulk.content.indexOf('id: "export-3"'), 'bulk export order is not newest first');
   assert(!bulk.content.includes('id: "export-2"'), 'filtered-out record leaked into bulk export');
   assert(
-    bulk.content.includes('newest consultation transcript\n\n---\nid: "export-3"'),
+    bulk.content.includes('legacy-cost-marker\n\n---\nid: "export-3"'),
     'bulk export separator contract mismatch'
+  );
+
+  const imported = await page.evaluate(async markdown => {
+    confirm = () => true;
+    AppState.transcriptChunks = [];
+    AppState.fullTranscript = '';
+    AppState.aiResponses = {
+      summary: [], opinion: [], idea: [], consult: [], minutes: '', custom: []
+    };
+    document.getElementById('meetingTitleInput').value = '';
+    await importFromMarkdown({
+      name: 'export-1.md',
+      text: async () => markdown
+    });
+    return {
+      title: document.getElementById('meetingTitleInput').value,
+      minutes: AppState.aiResponses.minutes,
+      transcript: AppState.transcriptChunks.map(chunk => chunk.text).join('\n')
+    };
+  }, single.content);
+  assert(imported.title === '資金: #確認', `imported title mismatch: ${imported.title}`);
+  assert(imported.minutes === '議事録の本文', `imported minutes mismatch: ${imported.minutes}`);
+  assert(
+    imported.transcript === 'newest consultation transcript\nsecond transcript line',
+    `imported transcript mismatch: ${imported.transcript}`
   );
 }
 

--- a/tests/unit/export-service.test.mjs
+++ b/tests/unit/export-service.test.mjs
@@ -107,6 +107,25 @@ describe('ExportService', () => {
     assert.match(markdown, /## 文字起こし\n\nraw transcript/);
   });
 
+  it('preserves the stored legacy export payload after the new record contract', () => {
+    const markdown = ExportService.generateRecordMarkdown({
+      id: 'legacy-1',
+      title: '互換性確認',
+      createdAt: '2026-07-18T04:00:00.000Z',
+      profile: 'meeting',
+      category: '会議・打合せ',
+      tags: [],
+      status: 'raw',
+      transcript: 'new contract transcript',
+      exportMarkdown: '# 旧出力\n\n## 💬 AI回答\n\nlegacy-summary-marker\n\n## 💰 コスト詳細\n\nlegacy-cost-marker\n'
+    });
+
+    assert.match(markdown, /## 文字起こし\n\nnew contract transcript/);
+    assert.match(markdown, /## 保存時の詳細出力（従来形式）/);
+    assert.match(markdown, /legacy-summary-marker/);
+    assert.match(markdown, /legacy-cost-marker/);
+  });
+
   it('concatenates records with a blank line before each next front matter block', () => {
     const first = {
       id: 'newer', title: 'Newer', createdAt: '2026-07-18T00:00:00Z',


### PR DESCRIPTION
## Summary

- front matter付き履歴Markdown出力に、保存時の従来形式詳細出力を付録として保持
- front matter付き新形式と従来の絵文字見出し・`<details>`形式の両方をインポート可能に修正
- 新形式の出力→実インポート往復と旧形式インポートの回帰テストを追加

## Root cause

front matter形式への移行時、履歴レコードに保存済みの `exportMarkdown` が新しい出力契約へ引き継がれず、要約・AI回答・コスト詳細などが出力から欠落していました。また、既存のインポーターは従来形式だけを解析しており、新形式で出力したMarkdownを正しく復元できませんでした。

## Impact

既存履歴の詳細内容を失わずに新しいfront matter形式で書き出せます。新旧どちらのMarkdownも読み込めるため、過去ファイルとの後方互換性と新形式の往復互換性を回復します。

項目選択式Markdown出力、HistoryStore API/スキーマ、録音・STT・構造化productionロジックには変更を加えていません。

## Validation

- `git diff --check`: PASS
- ESLint: PASS
- i18n / UI smoke: PASS
- Unit: 273/273 PASS
- 実ブラウザ出力→インポート往復: PASS
- 旧形式インポート: PASS
- 全E2E（T1〜T3、H1、H2、P1、S1〜S11等）: ALL PASS

Closes #202