### PR TITLE
chore: .gitignore に .env 系を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 
+# 秘匿情報（APIキー・トークン）。作業ツリーに置いてもコミットされないようにする
+.env
+.env.*
+!.env.example
+
 .serena/
 .DS_Store
 node_modules/


### PR DESCRIPTION
## 何をしたか

`.gitignore` に `.env` の記載が無く、`git check-ignore .env` が exit 1 の状態だった。APIキーを扱うコード（`js/config.js`, `js/services/llm-client.js`, `js/stt/providers/deepgram_ws.js` など）があるため、`.env` を置いた瞬間にコミットされうる。その穴を塞ぐ。

## 変更点

- `.gitignore` の先頭に `.env` / `.env.*` を追加し、`!.env.example` で雛形だけ除外対象から外した。
- 既存の除外設定（`.serena/`, `node_modules/`, `.aion-ops/` 等）は変更していない。コード変更なし。

## 確認してほしいこと

- 判断: 依頼の `.env.local` / `.env.*.local` は `.env.*` に含めて一括で塞いでいます（`.env.production` のような依頼外の名前も漏らさないため）。明示列挙に戻したい場合は差し戻してください。
- リスク: 低。追跡中ファイルが新たに除外されないことを確認済み（`git ls-files --cached -i --exclude-standard` が0件、追跡164ファイルで増減なし）。現在repo内に `.env` 系ファイルは存在しません。
- 動作確認: `.env` / `.env.local` / `.env.production.local` が ignored、`.env.example` は NOT ignored。
- Todoist/gate: gate/human。mergeはHUMANのみ。

補足: `.gitignore` はコミットに対する防御であり、AIエージェントの読み取りには効きません。保管場所そのもののルールは aion-ops 側の別PR（gatyoukatyou/aion-ops#42）で扱っています。